### PR TITLE
minor: removed braces around scalar initializer

### DIFF
--- a/src/medida/reporting/json_reporter.cc
+++ b/src/medida/reporting/json_reporter.cc
@@ -89,7 +89,7 @@ JsonReporter::Impl::Impl(JsonReporter& self, MetricsRegistry &registry)
 	}
 #else
   utsname name;
-  uname_ = {uname(&name) ? "localhost" : name.nodename};
+  uname_ = uname(&name) ? "localhost" : name.nodename;
 #endif
 }
 


### PR DESCRIPTION
To avoid:
libmedida/src/medida/reporting/json_reporter.cc:92:12: warning: braces
around scalar initializer [-Wbraced-scalar-init]
  uname_ = {uname(&name) ? "localhost" : name.nodename};