### PR TITLE
Report sums of timers and histograms (they are already collected).

### DIFF
--- a/src/medida/reporting/collectd_reporter.cc
+++ b/src/medida/reporting/collectd_reporter.cc
@@ -222,6 +222,10 @@ void CollectdReporter::Impl::Process(Histogram& histogram) {
     {kGauge, snapshot.get98thPercentile()},
     {kGauge, snapshot.get99thPercentile()},
     {kGauge, snapshot.get999thPercentile()},
+    // Put 'sum' on the end as it seems clients are assumed to
+    // be accessing these metrics by position and we do not
+    // want to break them.
+    {kGauge, histogram.sum()},
   });
 }
 
@@ -241,6 +245,10 @@ void CollectdReporter::Impl::Process(Timer& timer) {
     {kGauge, snapshot.get98thPercentile()},
     {kGauge, snapshot.get99thPercentile()},
     {kGauge, snapshot.get999thPercentile()},
+    // Put 'sum' on the end as it seems clients are assumed to
+    // be accessing these metrics by position and we do not
+    // want to break them.
+    {kGauge, timer.sum()},
   });
 }
 

--- a/src/medida/reporting/console_reporter.cc
+++ b/src/medida/reporting/console_reporter.cc
@@ -112,6 +112,7 @@ void ConsoleReporter::Impl::Process(Histogram& histogram) {
        << "             max = " << histogram.max() << std::endl
        << "            mean = " << histogram.mean() << std::endl
        << "          stddev = " << histogram.std_dev() << std::endl
+       << "             sum = " << histogram.sum() << std::endl
        << "          median = " << snapshot.getMedian() << std::endl
        << "             75% = " << snapshot.get75thPercentile() << std::endl
        << "             95% = " << snapshot.get95thPercentile() << std::endl
@@ -134,6 +135,7 @@ void ConsoleReporter::Impl::Process(Timer& timer) {
        << "             max = " << timer.max() << unit << std::endl
        << "            mean = " << timer.mean() << unit << std::endl
        << "          stddev = " << timer.std_dev() << unit << std::endl
+       << "             sum = " << timer.sum() << unit << std::endl
        << "          median = " << snapshot.getMedian() << unit << std::endl
        << "             75% = " << snapshot.get75thPercentile() << unit << std::endl
        << "             95% = " << snapshot.get95thPercentile() << unit << std::endl

--- a/src/medida/reporting/json_reporter.cc
+++ b/src/medida/reporting/json_reporter.cc
@@ -170,6 +170,7 @@ void JsonReporter::Impl::Process(Histogram& histogram) {
        << "\"max\":" << histogram.max() << "," << std::endl
        << "\"mean\":" << histogram.mean() << "," << std::endl
        << "\"stddev\":" << histogram.std_dev() << "," << std::endl
+       << "\"sum\":" << histogram.sum() << "," << std::endl
        << "\"median\":" << snapshot.getMedian() << "," << std::endl
        << "\"75%\":" << snapshot.get75thPercentile() << "," << std::endl
        << "\"95%\":" << snapshot.get95thPercentile() << "," << std::endl
@@ -196,6 +197,7 @@ void JsonReporter::Impl::Process(Timer& timer) {
        << "\"max\":" << timer.max() << "," << std::endl
        << "\"mean\":" << timer.mean() << "," << std::endl
        << "\"stddev\":" << timer.std_dev() << "," << std::endl
+       << "\"sum\":" << timer.sum() << "," << std::endl
        << "\"median\":" << snapshot.getMedian() << "," << std::endl
        << "\"75%\":" << snapshot.get75thPercentile() << "," << std::endl
        << "\"95%\":" << snapshot.get95thPercentile() << "," << std::endl


### PR DESCRIPTION
We were not reporting sums of timers and histograms. Prometheus really wants those, and they're available. I think they were just omitted by accident.