### PR TITLE
Fixed non compiling code using Visual Studio 2019

### DIFF
--- a/src/medida/metered_interface.h
+++ b/src/medida/metered_interface.h
@@ -5,6 +5,8 @@
 #ifndef MEDIDA_METERED_INTERFACE_H_
 #define MEDIDA_METERED_INTERFACE_H_
 
+#include <string>
+
 #include "medida/types.h"
 
 namespace medida {

--- a/src/medida/timer_context.cc
+++ b/src/medida/timer_context.cc
@@ -2,6 +2,8 @@
 // Copyright (c) 2012 Daniel Lundin
 //
 
+#include <stdexcept>
+
 #include "medida/timer_context.h"
 
 #include "medida/timer.h"


### PR DESCRIPTION
There were missing include statements in the medida repository. This leaded to code not being compiled.

It was pure luck that the code compiled with the GNU compiler and previous versions of the Microsoft compiler. For example include file 'functional' included 'array', 'array' included 'stdexcept' and 'stdexcept' included 'string'. In the lastest version of the Microsoft compiler this is not anymore the case.

We should directly declare the include files where we depend on and not rely on indirectly declared dependencies.