### PR TITLE
report counts of histograms

### DIFF
--- a/src/medida/reporting/collectd_reporter.cc
+++ b/src/medida/reporting/collectd_reporter.cc
@@ -212,6 +212,7 @@ void CollectdReporter::Impl::Process(Meter& meter) {
 
 void CollectdReporter::Impl::Process(Histogram& histogram) {
   auto snapshot = histogram.GetSnapshot();
+  double count = histogram.count();
   AddPart(kType, "medida_histogram");
   AddPart(kTypeInstance, current_instance_);
   AddValues({
@@ -225,16 +226,18 @@ void CollectdReporter::Impl::Process(Histogram& histogram) {
     {kGauge, snapshot.get98thPercentile()},
     {kGauge, snapshot.get99thPercentile()},
     {kGauge, snapshot.get999thPercentile()},
-    // Put 'sum' on the end as it seems clients are assumed to
+    // Put 'sum', 'count' on the end as it seems clients are assumed to
     // be accessing these metrics by position and we do not
     // want to break them.
     {kGauge, histogram.sum()},
+    {kGauge, count},
   });
 }
 
 
 void CollectdReporter::Impl::Process(Timer& timer) {
   auto snapshot = timer.GetSnapshot();
+  double count = timer.count();
   AddPart(kType, "medida_timer");
   AddPart(kTypeInstance, current_instance_ + "." + FormatRateUnit(timer.duration_unit()));
   AddValues({
@@ -248,10 +251,11 @@ void CollectdReporter::Impl::Process(Timer& timer) {
     {kGauge, snapshot.get98thPercentile()},
     {kGauge, snapshot.get99thPercentile()},
     {kGauge, snapshot.get999thPercentile()},
-    // Put 'sum' on the end as it seems clients are assumed to
+    // Put 'sum', 'count' on the end as it seems clients are assumed to
     // be accessing these metrics by position and we do not
     // want to break them.
     {kGauge, timer.sum()},
+    {kGauge, count},
   });
 }
 

--- a/src/medida/reporting/console_reporter.cc
+++ b/src/medida/reporting/console_reporter.cc
@@ -108,7 +108,8 @@ void ConsoleReporter::Impl::Process(Meter& meter) {
 
 void ConsoleReporter::Impl::Process(Histogram& histogram) {
   auto snapshot = histogram.GetSnapshot();
-  out_ << "             min = " << histogram.min() << std::endl
+  out_ << "           count = " << histogram.count() << std::endl
+       << "             min = " << histogram.min() << std::endl
        << "             max = " << histogram.max() << std::endl
        << "            mean = " << histogram.mean() << std::endl
        << "          stddev = " << histogram.std_dev() << std::endl

--- a/src/medida/reporting/json_reporter.cc
+++ b/src/medida/reporting/json_reporter.cc
@@ -166,6 +166,7 @@ void JsonReporter::Impl::Process(Histogram& histogram) {
 #undef max
 #endif
   out_ << "\"type\":\"histogram\"," << std::endl
+       << "\"count\":" << histogram.count() << "," << std::endl
        << "\"min\":" << histogram.min() << "," << std::endl
        << "\"max\":" << histogram.max() << "," << std::endl
        << "\"mean\":" << histogram.mean() << "," << std::endl


### PR DESCRIPTION
histograms are already collecting count, this PR exposes it via the collectd, console, json reporters.

* enables us to scrape histogram metric types with the Prometheus stellar-core exporter (https://github.com/stellar/packages/issues/57)