### PR TITLE
Add some batch-update interfaces.

### DIFF
--- a/src/medida/histogram.h
+++ b/src/medida/histogram.h
@@ -26,6 +26,7 @@ class Histogram : public MetricInterface, SamplingInterface, SummarizableInterfa
   virtual double mean() const;
   virtual double std_dev() const;
   void Update(std::int64_t value);
+  void Update(std::vector<std::int64_t> const& values);
   std::uint64_t count() const;
   double variance() const;
   void Process(MetricProcessor& processor);

--- a/src/medida/stats/exp_decay_sample.h
+++ b/src/medida/stats/exp_decay_sample.h
@@ -22,7 +22,9 @@ class ExpDecaySample : public Sample {
   virtual void Clear();
   virtual std::uint64_t size() const;
   virtual void Update(std::int64_t value);
+  virtual void Update(std::vector<std::int64_t> const& values);
   virtual void Update(std::int64_t value, Clock::time_point timestamp);
+  virtual void Update(std::vector<std::int64_t> const& values, Clock::time_point timestamp);
   virtual Snapshot MakeSnapshot() const;
  private:
   class Impl;

--- a/src/medida/stats/sample.h
+++ b/src/medida/stats/sample.h
@@ -19,6 +19,7 @@ public:
   virtual void Clear() = 0;
   virtual std::uint64_t size() const = 0;
   virtual void Update(std::int64_t value) = 0;
+  virtual void Update(std::vector<std::int64_t> const& values) = 0;
   virtual Snapshot MakeSnapshot() const = 0;
 };
 

--- a/src/medida/stats/uniform_sample.h
+++ b/src/medida/stats/uniform_sample.h
@@ -21,6 +21,7 @@ class UniformSample : public Sample {
   virtual void Clear();
   virtual std::uint64_t size() const;
   virtual void Update(std::int64_t value);
+  virtual void Update(std::vector<std::int64_t> const& values);
   virtual Snapshot MakeSnapshot() const;
  private:
   class Impl;

--- a/src/medida/timer.cc
+++ b/src/medida/timer.cc
@@ -33,6 +33,7 @@ class Timer::Impl {
   std::chrono::nanoseconds duration_unit() const;
   void Clear();
   void Update(std::chrono::nanoseconds duration);
+  void Update(std::vector<std::chrono::nanoseconds> durations);
   TimerContext TimeScope();
   void Time(std::function<void()>);
  private:
@@ -134,6 +135,9 @@ void Timer::Update(std::chrono::nanoseconds duration) {
   impl_->Update(duration);
 }
 
+void Timer::Update(std::vector<std::chrono::nanoseconds> durations) {
+  impl_->Update(durations);
+}
 
 stats::Snapshot Timer::GetSnapshot() const {
   return impl_->GetSnapshot();
@@ -248,6 +252,21 @@ void Timer::Impl::Update(std::chrono::nanoseconds duration) {
     histogram_.Update(count);
     meter_.Mark();
   }
+}
+
+
+void Timer::Impl::Update(std::vector<std::chrono::nanoseconds> durations) {
+  std::vector<std::int64_t> counts(durations.size());
+  for (auto const& ns : durations)
+  {
+    auto count = ns.count();
+    if (count != 0)
+    {
+      counts.emplace_back(count);
+    }
+  };
+  histogram_.Update(counts);
+  meter_.Mark(counts.size());
 }
 
 

--- a/src/medida/timer.h
+++ b/src/medida/timer.h
@@ -41,6 +41,7 @@ class Timer : public MetricInterface, MeteredInterface, SamplingInterface, Summa
   std::chrono::nanoseconds duration_unit() const;
   void Clear();
   void Update(std::chrono::nanoseconds duration);
+  void Update(std::vector<std::chrono::nanoseconds> durations);
   TimerContext TimeScope();
   void Time(std::function<void()>);
  private:


### PR DESCRIPTION
This just adds a new set of interfaces that allow batch updates to metrics, taking fewer locks.