### PR TITLE
Change the ExpDecaySample class to use seconds, not milliseconds.

### DIFF
--- a/src/medida/stats/exp_decay_sample.cc
+++ b/src/medida/stats/exp_decay_sample.cc
@@ -120,7 +120,7 @@ void ExpDecaySample::Impl::Update(std::int64_t value, Clock::time_point timestam
       Rescale(timestamp);
     }
     std::lock_guard<std::mutex> lock {mutex_};
-    auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(timestamp - startTime_);
+    auto dur = std::chrono::duration_cast<std::chrono::seconds>(timestamp - startTime_);
     auto priority = std::exp(alpha_ * dur.count()) / dist_(rng_);
     auto count = ++count_;
 
@@ -157,7 +157,7 @@ void ExpDecaySample::Impl::Rescale(const Clock::time_point& when) {
   values_.clear();
 
   for (size_t i = 0; i < size; i++) {
-    auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(when - oldStartTime);
+    auto dur = std::chrono::duration_cast<std::chrono::seconds>(when - oldStartTime);
     auto key = keys[i] * std::exp(-alpha_ * dur.count());
     values_[key] = values[i];
   }


### PR DESCRIPTION
TL;DR: this appears to fix the "broken percentiles" in medida.

Longer:

As far as I can tell, the reason the percentiles coming out of medida
are "mostly useless" is that the medida author took an incorrect liberty
when transcribing ExponentiallyDecayingReservoir.java from the original
code in DropWizard Metrics.

That original code (which is cute but weird!) approaches the problem of
"exponentially decaying reservoir" using a bit of a cheap trick. The
trick is to put elements in a _sorted map_ (keyed by doubles) and expire
elements from the small end of the map, adding entries randomly but
ever-more-exponentially biased towards the large end as time passes.
This is done by making a "priority value" that's exp(age-in-seconds *
0.015) to make the values cover the entire range of doubles within an
hour (actually, by my math, maybe single precision floats?
exp(3600*0.015) = 2.8e23 and floats have 23 bits mantissa..), after
which the values are rescaled and the anchor second for calculating age
is reset. So far so good (if a little weird).

Unfortunately in medida (presumably on the thought that "seconds are
good, milliseconds must be better") the author changed this to a count
of milliseconds, without changing the scaling factor or anything else in
the math. Unfortunately the exponential of the map's age in
_milliseconds_ is quite a bit larger, and overflows a double within a
few seconds, resulting in totally nonsensical ordering.