### PR TITLE
Add a sliding window reservoir type and switch timer to use it.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ set(medida_SOURCES
   src/medida/stats/ewma.cc
   src/medida/stats/uniform_sample.cc
   src/medida/stats/exp_decay_sample.cc
+  src/medida/stats/sliding_window_sample.cc
   src/medida/counter.cc
   src/medida/meter.cc
   src/medida/metric_name.cc
@@ -67,6 +68,7 @@ set(medida_HEADERS
   src/medida/reporting/util.h
   src/medida/stats/ewma.h
   src/medida/stats/exp_decay_sample.h
+  src/medida/stats/sliding_window_sample.h
   src/medida/stats/sample.h
   src/medida/stats/snapshot.h
   src/medida/stats/uniform_sample.h
@@ -130,6 +132,7 @@ install(FILES
 install(FILES
   src/medida/stats/ewma.h
   src/medida/stats/exp_decay_sample.h
+  src/medida/stats/sliding_window_sample.h
   src/medida/stats/sample.h
   src/medida/stats/snapshot.h
   src/medida/stats/uniform_sample.h

--- a/src/medida/histogram.cc
+++ b/src/medida/histogram.cc
@@ -10,10 +10,15 @@
 
 #include "medida/stats/exp_decay_sample.h"
 #include "medida/stats/uniform_sample.h"
+#include "medida/stats/sliding_window_sample.h"
 
 namespace medida {
 
 static const double kDefaultAlpha = 0.015;
+
+// Sliding windows are 5 minutes by default. They also respect the sample-size
+// limit by stochastic rate-limiting of additions.
+static const std::chrono::seconds kDefaultWindowTime = std::chrono::seconds(5 * 60);
 
 class Histogram::Impl {
  public:
@@ -114,6 +119,9 @@ Histogram::Impl::Impl(SampleType sample_type) {
     sample_ = std::unique_ptr<stats::Sample>(new stats::UniformSample(kDefaultSampleSize));
   } else if (sample_type == kBiased) {
     sample_ = std::unique_ptr<stats::Sample>(new stats::ExpDecaySample(kDefaultSampleSize, kDefaultAlpha));
+  } else if (sample_type == kSliding) {
+    sample_ = std::unique_ptr<stats::Sample>(new stats::SlidingWindowSample(kDefaultSampleSize,
+                                                                            kDefaultWindowTime));
   } else {
       throw std::invalid_argument("invalid sample_type");
   }

--- a/src/medida/sampling_interface.h
+++ b/src/medida/sampling_interface.h
@@ -11,7 +11,7 @@ namespace medida {
 
 class SamplingInterface {
 public:
-  enum SampleType { kUniform, kBiased };
+  enum SampleType { kUniform, kBiased, kSliding };
   virtual ~SamplingInterface() {};
   virtual stats::Snapshot GetSnapshot() const = 0;
 };

--- a/src/medida/stats/sliding_window_sample.cc
+++ b/src/medida/stats/sliding_window_sample.cc
@@ -1,0 +1,230 @@
+// Copyright 2020 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "medida/stats/sliding_window_sample.h"
+
+#include <cassert>
+#include <chrono>
+#include <deque>
+#include <mutex>
+#include <random>
+
+#include "medida/stats/snapshot.h"
+
+namespace medida
+{
+namespace stats
+{
+
+class SlidingWindowSample::Impl
+{
+  public:
+    Impl(std::size_t windowSize, std::chrono::seconds windowTime);
+    ~Impl();
+    void Clear();
+    std::uint64_t size();
+    void Update(std::int64_t value);
+    void Update(std::int64_t value, Clock::time_point timestamp);
+    Snapshot MakeSnapshot();
+
+  private:
+    std::mutex mutex_;
+    const std::size_t windowSize_;
+    const std::chrono::seconds windowTime_;
+    const std::chrono::microseconds timeSlice_;
+    std::uint32_t samplesInCurrentSlice_;
+    std::default_random_engine rng_;
+    std::uniform_int_distribution<std::uint32_t> dist_;
+    std::deque<std::pair<double, Clock::time_point>> values_;
+};
+
+SlidingWindowSample::SlidingWindowSample(std::size_t windowSize,
+                                         std::chrono::seconds windowTime)
+    : impl_{new SlidingWindowSample::Impl{windowSize, windowTime}}
+{
+}
+
+SlidingWindowSample::~SlidingWindowSample()
+{
+}
+
+void
+SlidingWindowSample::Clear()
+{
+    impl_->Clear();
+}
+
+std::uint64_t
+SlidingWindowSample::size() const
+{
+    return impl_->size();
+}
+
+void
+SlidingWindowSample::Update(std::int64_t value)
+{
+    impl_->Update(value);
+}
+
+void
+SlidingWindowSample::Update(std::int64_t value, Clock::time_point timestamp)
+{
+    impl_->Update(value, timestamp);
+}
+
+Snapshot
+SlidingWindowSample::MakeSnapshot() const
+{
+    return impl_->MakeSnapshot();
+}
+
+// === Implementation ===
+
+SlidingWindowSample::Impl::Impl(std::size_t windowSize,
+                                std::chrono::seconds windowTime)
+    : windowSize_(windowSize)
+    , windowTime_(windowTime)
+    , timeSlice_(
+          std::chrono::duration_cast<std::chrono::microseconds>(windowTime) /
+          windowSize)
+    , samplesInCurrentSlice_(0)
+    , rng_(std::random_device()())
+    , dist_(0, std::numeric_limits<std::uint32_t>::max())
+{
+    Clear();
+}
+
+SlidingWindowSample::Impl::~Impl()
+{
+}
+
+void
+SlidingWindowSample::Impl::Clear()
+{
+    std::lock_guard<std::mutex> lock{mutex_};
+    values_.clear();
+}
+
+std::uint64_t
+SlidingWindowSample::Impl::size()
+{
+    std::lock_guard<std::mutex> lock{mutex_};
+    return values_.size();
+}
+
+void
+SlidingWindowSample::Impl::Update(std::int64_t value)
+{
+    Update(value, Clock::now());
+}
+
+void
+SlidingWindowSample::Impl::Update(std::int64_t value,
+                                  Clock::time_point timestamp)
+{
+    std::lock_guard<std::mutex> lock{mutex_};
+
+    if (!values_.empty())
+    {
+        // If we're in a new timeslice, reset count
+        if (timestamp > values_.back().second + timeSlice_)
+        {
+            samplesInCurrentSlice_ = 0;
+        }
+
+        // If there's old data, trim it.
+        Clock::time_point expiryTime = timestamp - windowTime_;
+        while (!values_.empty() && values_.front().second < expiryTime)
+        {
+            values_.pop_front();
+        }
+    }
+
+    // When you add samples to the sliding window _slowly_ nothing goes wrong;
+    // when you add them too _quickly_ there's the possibility of losing rare
+    // events because they're overwritten before they get observed.
+    //
+    // To compensate for this, we divide the total fixed-duration time window by
+    // the fixed number of samples we want to retain, resulting in fixed-size
+    // _timeslices_. And then within each timeslice we arrange to keep a random
+    // representative of the samples that arrive during that slice.
+
+    // Check if we've already inserted an item for the same timeSlice.
+    if (!values_.empty() && timestamp <= values_.back().second + timeSlice_)
+    {
+        // Here we're trying to cheaply (i.e. using only integer ops) calculate
+        // a condition that results in each of N samples being chosen with
+        // probability 1/N. Since we don't know N in advance, only as time
+        // proceeds, we achieve the goal by tracking the count K of samples
+        // we've received in a timeslice and repeatedly _replacing_ the Kth
+        // sample with probability 1/K.
+        //
+        // Proof that this behaviour is correct is by induction:
+        //
+        //  - When K = 1 obviously it is correct: 1/1 = 1/K = 1/N
+        //
+        //  - Now for case K, let J = K-1, and assume for N = J that the
+        //    replacement behaviour is correct, meaning that every sample so far
+        //    has an equal 1/J chance of being the current surviving
+        //    candidate. Now we replace that candidate with probability 1/K. The
+        //    new sample obviously has odds of being the new survivor with odds
+        //    1/K, and the previous survivor has odds 1/J * (1 - 1/K)
+        //
+        //      = 1/J - 1/JK         -- distributing
+        //      = K/JK - 1/JK        -- taking common denominator
+        //      = (K-1)/JK           -- applying -
+        //      = (K-1)/((K-1)K)     -- expanding definition of J
+        //      = 1/K                -- reducing fraction
+        //
+        //    Since the previous survivor is _any_ of the previous J samples,
+        //    they all now have the same 1/K chance of surviving this current
+        //    replacement.
+        //
+        // Next: to _accomplish_ replacement with probability 1/K, given K as
+        // the count of events so far (samplesInCurrentSlice_), we take M as the
+        // maximum uint32_t and R a random uint32_t, and check R * K <= M (with
+        // all values promoted to 64-bit so they won't overflow).
+        //
+        // Algebraically (if we were using real numbers) this is the same as
+        // checking RK / M <= 1 or R/M <= 1/K, where the R/M term varies between
+        // 0 and 1. When R is uniformly random, this condition is true exactly
+        // 1/K of the time, which is what we're after; and it can be calculated
+        // faithfully using integers when we write it as R*K <= M.
+
+        samplesInCurrentSlice_++;
+        uint32_t r = dist_(rng_);
+        uint64_t rk = uint64_t(r) * uint64_t(samplesInCurrentSlice_);
+        uint64_t m = uint64_t(std::numeric_limits<std::uint32_t>::max());
+        if (rk <= m)
+        {
+            // Keep old timestamp to anchor timeSlice; but replace value.
+            values_.back().first = value;
+        }
+    }
+    else
+    {
+        values_.emplace_back(value, timestamp);
+        samplesInCurrentSlice_ = 1;
+        if (values_.size() > windowSize_)
+        {
+            values_.pop_front();
+        }
+    }
+}
+
+Snapshot
+SlidingWindowSample::Impl::MakeSnapshot()
+{
+    std::lock_guard<std::mutex> lock{mutex_};
+    std::vector<double> vals;
+    vals.reserve(values_.size());
+    for (auto v : values_)
+    {
+        vals.emplace_back(v.first);
+    }
+    return {vals};
+}
+
+} // namespace stats
+} // namespace medida

--- a/src/medida/stats/sliding_window_sample.cc
+++ b/src/medida/stats/sliding_window_sample.cc
@@ -23,6 +23,7 @@ class SlidingWindowSample::Impl
     Impl(std::size_t windowSize, std::chrono::seconds windowTime);
     ~Impl();
     void Clear();
+    void Seed(size_t seed);
     std::uint64_t size();
     void Update(std::int64_t value);
     void Update(std::int64_t value, Clock::time_point timestamp);
@@ -53,6 +54,12 @@ void
 SlidingWindowSample::Clear()
 {
     impl_->Clear();
+}
+
+void
+SlidingWindowSample::Seed(size_t seed)
+{
+    impl_->Seed(seed);
 }
 
 std::uint64_t
@@ -97,6 +104,13 @@ SlidingWindowSample::Impl::Impl(std::size_t windowSize,
 
 SlidingWindowSample::Impl::~Impl()
 {
+}
+
+void
+SlidingWindowSample::Impl::Seed(size_t seed)
+{
+    std::lock_guard<std::mutex> lock{mutex_};
+    rng_.seed(seed);
 }
 
 void

--- a/src/medida/stats/sliding_window_sample.h
+++ b/src/medida/stats/sliding_window_sample.h
@@ -27,6 +27,7 @@ class SlidingWindowSample : public Sample
     SlidingWindowSample(std::size_t windowSize,
                         std::chrono::seconds windowTime);
     ~SlidingWindowSample();
+    virtual void Seed(size_t);
     virtual void Clear();
     virtual std::uint64_t size() const;
     virtual void Update(std::int64_t value);

--- a/src/medida/stats/sliding_window_sample.h
+++ b/src/medida/stats/sliding_window_sample.h
@@ -1,0 +1,44 @@
+// Copyright 2020 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#ifndef MEDIDA_SLIDING_WINDOW_SAMPLE_H_
+#define MEDIDA_SLIDING_WINDOW_SAMPLE_H_
+
+#include <cstdint>
+#include <memory>
+
+#include "medida/stats/sample.h"
+#include "medida/types.h"
+
+namespace medida
+{
+namespace stats
+{
+
+// Sliding window has both a size limit and time limit: samples are expired by
+// time and/or size, with excess size-based expiries in a given time slice used
+// to stochastically rate-limit further additions within that slice.
+
+class SlidingWindowSample : public Sample
+{
+  public:
+    SlidingWindowSample() = delete;
+    SlidingWindowSample(std::size_t windowSize,
+                        std::chrono::seconds windowTime);
+    ~SlidingWindowSample();
+    virtual void Clear();
+    virtual std::uint64_t size() const;
+    virtual void Update(std::int64_t value);
+    virtual void Update(std::int64_t value, Clock::time_point timestamp);
+    virtual Snapshot MakeSnapshot() const;
+
+  private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace stats
+} // namespace medida
+
+#endif // MEDIDA_EXP_DECAY_SAMPLE_H_

--- a/src/medida/timer.cc
+++ b/src/medida/timer.cc
@@ -159,7 +159,7 @@ Timer::Impl::Impl(Timer& self, std::chrono::nanoseconds duration_unit, std::chro
       duration_unit_nanos_ {duration_unit.count()},
       rate_unit_           {rate_unit},
       meter_               {"calls", rate_unit},
-      histogram_           {SamplingInterface::kBiased} {
+      histogram_           {SamplingInterface::kSliding} {
 }
 
 

--- a/test/test_timer.cc
+++ b/test/test_timer.cc
@@ -56,10 +56,16 @@ TEST_F(TimerTest, aBlankTimer) {
 
 
 TEST_F(TimerTest, timingASeriesOfEvents) {
+  // Need to sleep between events so sliding window assigns
+  // them to separate timeslices.
   timer.Update(std::chrono::milliseconds(10));
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
   timer.Update(std::chrono::milliseconds(20));
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
   timer.Update(std::chrono::milliseconds(20));
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
   timer.Update(std::chrono::milliseconds(30));
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
   timer.Update(std::chrono::milliseconds(40));
 
   EXPECT_EQ(5, timer.count());


### PR DESCRIPTION
Rather than fussing with the [endless disappointments of exponential-decay reservoir sampling](https://medium.com/expedia-group-tech/your-latency-metrics-could-be-misleading-you-how-hdrhistogram-can-help-9d545b598374), I decided to follow [the internet's advice](https://engineering.salesforce.com/be-careful-with-reservoirs-708884018daf) (and the [Dropwizard Metrics Library's later change of course](https://metrics.dropwizard.io/4.0.5/manual/core.html#sliding-time-window-reservoirs)) and implement a sliding window sample type instead.

This is _slightly_ different from other sliding windows, in that it is both time _and_ space-bounded: if you add data to it "too fast" for a given timeslice (i.e. more than once every time/space seconds, in practice 5min / 1028 = 0.29 seconds) it will throttle subsequent additions (stochastically) in that timeslice to remain at a fixed size. This gives rare events an even (ish) chance across a given window of surviving long enough to be observed; or at least each timeslice gets an even subsample of the window's events. Ish. I think.

The PR also changes the default sample type used by timers to use this sliding window. I tried it out in production on stellar-core and it seems to produce more-reasonable stats (i.e. the p99 of a slow event like `scp.timing.externalized` changes within 5 minutes, not 18+ hours; and the p99 of fast events like `overlay.delay.async-write` changes only relatively-gradually over minutes, not like different-at-every-glance which you get with a pure size-limited sliding window.)