### PR TITLE
make libmedida use stellar::uniform_int_distribution

### DIFF
--- a/src/medida/stats/sliding_window_sample.cc
+++ b/src/medida/stats/sliding_window_sample.cc
@@ -9,6 +9,7 @@
 #include <deque>
 #include <mutex>
 #include <random>
+#include <stdrandom.h>
 
 #include "medida/stats/snapshot.h"
 
@@ -36,7 +37,7 @@ class SlidingWindowSample::Impl
     const std::chrono::microseconds timeSlice_;
     std::uint32_t samplesInCurrentSlice_;
     std::default_random_engine rng_;
-    std::uniform_int_distribution<std::uint32_t> dist_;
+    stellar::uniform_int_distribution<std::uint32_t> dist_;
     std::deque<std::pair<double, Clock::time_point>> values_;
 };
 

--- a/src/medida/stats/uniform_sample.cc
+++ b/src/medida/stats/uniform_sample.cc
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <mutex>
 #include <random>
+#include <stdrandom.h>
 #include <vector>
 
 namespace medida {
@@ -97,7 +98,7 @@ void UniformSample::Impl::Update(std::int64_t value) {
   if (count < size) {
     values_[count - 1] = value;
   } else {
-    std::uniform_int_distribution<uint64_t> uniform(0, count - 1);
+    stellar::uniform_int_distribution<uint64_t> uniform(0, count - 1);
     auto rand = uniform(rng_);
     if (rand < size) {
       values_[rand] = value;


### PR DESCRIPTION
This is a bit ridiculous but just to be certain -- sometimes we read back stats from medida in tests, in which case we risk being stdlib-specific in behaviour unless we redirect medida to also use `stellar::uniform_int_distribution`