### PR TITLE
Update the CKMS class to calculate the exact percentiles until we have 500 elements

### DIFF
--- a/src/medida/stats/ckms.h
+++ b/src/medida/stats/ckms.h
@@ -60,6 +60,7 @@ class CKMS {
   std::vector<Item> sample_;
   std::array<double, 500> buffer_;
   std::size_t buffer_count_;
+  std::size_t size_when_last_sorted_;
 
   double max_;
 };

--- a/test/stats/test_ckms_sample.cc
+++ b/test/stats/test_ckms_sample.cc
@@ -125,3 +125,28 @@ TEST(CKMSSampleTest, aCKMSUpdateWithHugeGap) {
   auto snapshot = sample.MakeSnapshot(t);
   EXPECT_EQ(2, snapshot.size());
 }
+
+TEST(CKMSSampleTest, aSpikyInputs) {
+  CKMSSample sample;
+
+  auto t = medida::Clock::now();
+
+  auto const size = 100000;
+  for (auto i = 0; i < 5; i++) {
+    t += std::chrono::seconds(30);
+    for (int j = 1; j <= size; j++) {
+      sample.Update(j, t);
+    }
+  }
+
+  EXPECT_EQ(size, sample.size(t));
+
+  auto snapshot = sample.MakeSnapshot(t);
+
+  // Allow the result to be off by 0.1%.
+  auto error = 0.001;
+  EXPECT_NEAR(size * 0.5, snapshot.getValue(0.5), size * error);
+  EXPECT_NEAR(size * 0.99, snapshot.getValue(0.99), size * error);
+  EXPECT_NEAR(size, snapshot.getValue(1), size * error);
+}
+


### PR DESCRIPTION
CKMS seems to struggle when the input size is too small. (e.g., P99 for {1, 2, 3, 4} never seems accurate).

The CKMS class has a buffer array of 500 elements to avoid having to update its data structure for every insert operation. This PR makes use of that buffer, and it simply sorts the buffer array to calculate percentiles until the buffer is full. Once the buffer is full, it inserts the buffered elements into the efficient data structure to avoid memory usage explosion.

- It returns the smallest element `x` such that at least `q`% of the given elements are `<= x` if we have less than 500 elements.
- It sorts the buffer array whenever we calculate the percentile. (Unless, of course, we had just sorted it). This means we sort the array up to 500 times, and thus may lead to `O(500 * 500 * log(500))` operations (approx 700k ops). However, the main usecase of the CKMS class is in CKMSSample which resets the metrics every 30 seconds. It seems extremely unlikely that one would insert 500 elements and check percentiles after every insert operation within 30 seconds.
- This PR doesn't use any extra memory except for one integer member variable.

