### PR TITLE
Round the starting time when calculating the beginnning of a time

### DIFF
--- a/src/medida/stats/ckms_sample.cc
+++ b/src/medida/stats/ckms_sample.cc
@@ -77,7 +77,8 @@ Snapshot CKMSSample::MakeSnapshot(SystemClock::time_point timestamp, uint64_t di
 // === Implementation ===
 
 SystemClock::time_point CKMSSample::Impl::CalculateCurrentWindowStartingPoint(SystemClock::time_point time) const {
-    return time - (std::chrono::duration_cast<std::chrono::seconds>(time.time_since_epoch()) % window_size_);
+    auto offset = time.time_since_epoch() % std::chrono::duration_cast<SystemClock::time_point::duration>(window_size_);
+    return time - offset;
 }
 
 bool CKMSSample::Impl::IsInCurrentWindow(SystemClock::time_point const& timestamp) const {


### PR DESCRIPTION
`CalculateCurrentWindowStartingPoint` was incorrect.

For instance, if the given time was 12:00:00.5, then it should return 12:00:00 since 12:00:00.5 is a time point in [12:00:00, 12:00:30]. But the current implementation returns 12:00:00.