### PR TITLE
Metric optimizations for stellar-core apply path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set (medida_VERSION_MINOR 1)
 set (medida_VERSION_PATCH 0)
 set (medida_VERSION_TAG "")
 set (medida_VERSION "${medida_VERSION_MAJOR}.${medida_VERSION_MINOR}.${medida_VERSION_PATCH}${medida_VERSION_TAG}")
+option(MEDIDA_WITH_COLLECTD_REPORTER "Build the collectd reporter" ON)
 
 
 ## Configuration
@@ -17,7 +18,15 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fno-diagnostics-show-option -std=c++0x -Wall -Wextra -pedantic -Wno-long-long -Wno-deprecated -fno-strict-aliasing")
+if(MSVC)
+  add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
+else()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fno-diagnostics-show-option -Wall -Wextra -pedantic -Wno-long-long -Wno-deprecated -fno-strict-aliasing")
+endif()
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   include(FindPkgConfig)
@@ -43,12 +52,17 @@ set(medida_SOURCES
   src/medida/timer.cc
   src/medida/timer_context.cc
   src/medida/reporting/abstract_polling_reporter.cc
-  src/medida/reporting/collectd_reporter.cc
   src/medida/reporting/console_reporter.cc
   src/medida/reporting/json_reporter.cc
   src/medida/reporting/util.cc
   src/medida/histogram.cc
 )
+
+if(MEDIDA_WITH_COLLECTD_REPORTER AND NOT WIN32)
+  list(APPEND medida_SOURCES
+    src/medida/reporting/collectd_reporter.cc
+  )
+endif()
 
 set(medida_HEADERS
   src/medida/buckets.h
@@ -89,7 +103,13 @@ include_directories(
   ${medida_BINARY_DIR}
 )
 
-add_library(medida SHARED
+if(WIN32)
+  set(MEDIDA_LIBRARY_TYPE STATIC)
+else()
+  set(MEDIDA_LIBRARY_TYPE SHARED)
+endif()
+
+add_library(medida ${MEDIDA_LIBRARY_TYPE}
   ${medida_SOURCES}
   ${medida_PROTO_SRCS}
 )
@@ -97,6 +117,10 @@ add_library(medida SHARED
 target_link_libraries(medida
   ${CMAKE_THREAD_LIBS_INIT}
 )
+
+if(WIN32)
+  target_link_libraries(medida ws2_32)
+endif()
 
 set_target_properties(medida PROPERTIES
   OUTPUT_NAME medida
@@ -106,6 +130,7 @@ set_target_properties(medida PROPERTIES
 
 install(TARGETS medida
   LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
 )
 
 install(FILES

--- a/src/medida/buckets.cc
+++ b/src/medida/buckets.cc
@@ -4,7 +4,7 @@
 
 #include "medida/buckets.h"
 #include "medida/timer.h"
-#include <Tracy.hpp>
+#include "medida/tracy.h"
 #include <map>
 #include <memory>
 #include <mutex>

--- a/src/medida/counter.cc
+++ b/src/medida/counter.cc
@@ -3,7 +3,7 @@
 //
 
 #include "medida/counter.h"
-#include <Tracy.hpp>
+#include "medida/tracy.h"
 
 #include <atomic>
 

--- a/src/medida/histogram.cc
+++ b/src/medida/histogram.cc
@@ -3,7 +3,7 @@
 //
 
 #include "medida/histogram.h"
-#include <Tracy.hpp>
+#include "medida/tracy.h"
 
 #include <cmath>
 #include <mutex>

--- a/src/medida/histogram.cc
+++ b/src/medida/histogram.cc
@@ -34,6 +34,7 @@ class Histogram::Impl {
   double mean() const;
   double std_dev() const;
   void Update(std::int64_t value);
+  void UpdateMany(const std::vector<std::int64_t>& values);
   std::uint64_t count() const;
   double variance() const;
   void Process(MetricProcessor& processor);
@@ -47,7 +48,9 @@ class Histogram::Impl {
   std::uint64_t count_;
   double variance_m_;
   double variance_s_;
-  mutable std::recursive_mutex mutex_;
+  mutable std::mutex mutex_;
+  double variance_unlocked() const;
+  void update_stats_unlocked(std::int64_t value);
 };
 
 
@@ -116,6 +119,11 @@ void Histogram::Update(std::int64_t value) {
     impl_->Update(value);
 }
 
+void Histogram::UpdateMany(const std::vector<std::int64_t>& values) {
+    ZoneScoped;
+    impl_->UpdateMany(values);
+}
+
 stats::Snapshot Histogram::GetSnapshot() const {
     ZoneScoped;
     // We pass 1 here as dividing metrics by 1 changes nothing!
@@ -158,7 +166,7 @@ Histogram::Impl::~Impl() {
 
 
 void Histogram::Impl::Clear() {
-  std::lock_guard<std::recursive_mutex> lock {mutex_};
+  std::lock_guard<std::mutex> lock {mutex_};
   min_ = 0;
   max_ = 0;
   sum_ = 0;
@@ -170,19 +178,19 @@ void Histogram::Impl::Clear() {
 
 
 std::uint64_t Histogram::Impl::count() const {
-  std::lock_guard<std::recursive_mutex> lock {mutex_};
+  std::lock_guard<std::mutex> lock {mutex_};
   return count_;
 }
 
 
 double Histogram::Impl::sum() const {
-  std::lock_guard<std::recursive_mutex> lock {mutex_};
+  std::lock_guard<std::mutex> lock {mutex_};
   return sum_;
 }
 
 
 double Histogram::Impl::max() const {
-  std::lock_guard<std::recursive_mutex> lock {mutex_};
+  std::lock_guard<std::mutex> lock {mutex_};
   if (count_ > 0) {
     return max_;
   }
@@ -191,7 +199,7 @@ double Histogram::Impl::max() const {
 
 
 double Histogram::Impl::min() const {
-  std::lock_guard<std::recursive_mutex> lock {mutex_};
+  std::lock_guard<std::mutex> lock {mutex_};
   if (count_ > 0) {
     return min_;
   }
@@ -200,7 +208,7 @@ double Histogram::Impl::min() const {
 
 
 double Histogram::Impl::mean() const {
-  std::lock_guard<std::recursive_mutex> lock {mutex_};
+  std::lock_guard<std::mutex> lock {mutex_};
   if (count_ > 0) {
     return sum_ / (double)count_;
   }
@@ -209,8 +217,8 @@ double Histogram::Impl::mean() const {
 
 
 double Histogram::Impl::std_dev() const {
-  std::lock_guard<std::recursive_mutex> lock {mutex_};
-  double var = variance();
+  std::lock_guard<std::mutex> lock {mutex_};
+  double var = variance_unlocked();
   if (count_ > 0) {
     return std::sqrt(var);
   }
@@ -219,24 +227,45 @@ double Histogram::Impl::std_dev() const {
 
 
 double Histogram::Impl::variance() const {
-  std::lock_guard<std::recursive_mutex> lock {mutex_};
-  auto c = count();
-  if (c > 1) {
-    return variance_s_ / (c - 1.0);
+  std::lock_guard<std::mutex> lock {mutex_};
+  return variance_unlocked();
+}
+
+
+double Histogram::Impl::variance_unlocked() const {
+  if (count_ > 1) {
+    return variance_s_ / (count_ - 1.0);
   }
   return 0.0;
 }
 
 
 stats::Snapshot Histogram::Impl::GetSnapshot(uint64_t divisor) const {
-  std::lock_guard<std::recursive_mutex> lock {mutex_};
+  std::lock_guard<std::mutex> lock {mutex_};
   return sample_->MakeSnapshot(divisor);
 }
 
 
 void Histogram::Impl::Update(std::int64_t value) {
-  std::lock_guard<std::recursive_mutex> lock {mutex_};
+  std::lock_guard<std::mutex> lock {mutex_};
   sample_->Update(value);
+  update_stats_unlocked(value);
+}
+
+
+void Histogram::Impl::UpdateMany(const std::vector<std::int64_t>& values) {
+  if (values.empty()) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock {mutex_};
+  sample_->UpdateMany(values);
+  for (auto value : values) {
+    update_stats_unlocked(value);
+  }
+}
+
+
+void Histogram::Impl::update_stats_unlocked(std::int64_t value) {
   double dval = (double)value;
   if (count_ > 0) {
     max_ = std::max(max_, dval);

--- a/src/medida/histogram.h
+++ b/src/medida/histogram.h
@@ -36,6 +36,9 @@ class Histogram : public MetricInterface, SamplingInterface, SummarizableInterfa
   virtual double mean() const override;
   virtual double std_dev() const override;
   void Update(std::int64_t value);
+  // Record a batch of values with a single lock acquisition (and a single
+  // sample-window timestamp); equivalent to calling Update on each value.
+  void UpdateMany(const std::vector<std::int64_t>& values);
   std::uint64_t count() const;
   double variance() const;
   void Process(MetricProcessor& processor) override;

--- a/src/medida/meter.cc
+++ b/src/medida/meter.cc
@@ -6,11 +6,11 @@
 #include "medida/tracy.h"
 
 #include <atomic>
-#include <mutex>
+#include <thread>
 
 namespace medida {
 
-static const auto kTickInterval = Clock::duration(std::chrono::seconds(5)).count();
+static const auto kTickInterval = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::seconds(5)).count();
 
 class Meter::Impl {
  public:
@@ -30,12 +30,13 @@ class Meter::Impl {
   const std::string event_type_;
   const std::chrono::nanoseconds rate_unit_;
   std::atomic<std::uint64_t> count_;
-  Clock::time_point start_time_;
+  std::atomic<std::int64_t> start_time_;
   std::atomic<std::int64_t> last_tick_;
   stats::EWMA m1_rate_;
   stats::EWMA m5_rate_;
   stats::EWMA m15_rate_;
-  mutable std::mutex mutex_;
+  std::atomic<bool> ticking_;
+  static std::int64_t Now();
   void Tick();
   void TickIfNecessary();
 };
@@ -118,11 +119,12 @@ Meter::Impl::Impl(std::string event_type, std::chrono::nanoseconds rate_unit)
     : event_type_ (event_type),
       rate_unit_  (rate_unit),
       count_      (0),
-      start_time_ (Clock::now()),
-      last_tick_  (std::chrono::duration_cast<std::chrono::nanoseconds>(start_time_.time_since_epoch()).count()),
+      start_time_ (Now()),
+      last_tick_  (start_time_.load(std::memory_order_relaxed)),
       m1_rate_    (stats::EWMA::oneMinuteEWMA()),
       m5_rate_    (stats::EWMA::fiveMinuteEWMA()),
-      m15_rate_   (stats::EWMA::fifteenMinuteEWMA()) {
+      m15_rate_   (stats::EWMA::fifteenMinuteEWMA()),
+      ticking_    (false) {
 }
 
 
@@ -130,63 +132,58 @@ Meter::Impl::~Impl() {
 }
 
 
+std::int64_t Meter::Impl::Now() {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now().time_since_epoch()).count();
+}
+
+
 std::chrono::nanoseconds Meter::Impl::rate_unit() const {
-  // Mutex isn't strictly needed (rate_unit_ is a const),
-  // but add here to avoid warnings
-  std::lock_guard<std::mutex> lock {mutex_};
   return rate_unit_;
 }
 
 
 std::string Meter::Impl::event_type() const {
-  // Mutex isn't strictly needed (event_type_ is a const),
-  // but add here to avoid warnings
-  std::lock_guard<std::mutex> lock {mutex_};
   return event_type_;
 }
 
 
 std::uint64_t Meter::Impl::count() const {
-  return count_.load();
+  return count_.load(std::memory_order_relaxed);
 }
 
 
 double Meter::Impl::fifteen_minute_rate() {
-  std::lock_guard<std::mutex> lock {mutex_};
   TickIfNecessary();
   return m15_rate_.getRate();
 }
 
 
 double Meter::Impl::five_minute_rate() {
-  std::lock_guard<std::mutex> lock {mutex_};
   TickIfNecessary();
   return m5_rate_.getRate();
 }
 
 
 double Meter::Impl::one_minute_rate() {
-  std::lock_guard<std::mutex> lock {mutex_};
   TickIfNecessary();
   return m1_rate_.getRate();
 }
 
 
 double Meter::Impl::mean_rate() {
-  std::lock_guard<std::mutex> lock {mutex_};
-  double c = count_.load();
-  if (c > 0) {
-    std::chrono::nanoseconds elapsed = Clock::now() - start_time_;
-    return c * rate_unit_.count() / elapsed.count();
+  double c = count_.load(std::memory_order_relaxed);
+  auto start_time = start_time_.load(std::memory_order_relaxed);
+  auto elapsed = Now() - start_time;
+  if (c > 0 && elapsed > 0) {
+    return c * rate_unit_.count() / elapsed;
   }
   return 0.0;
 }
 
 
 void Meter::Impl::Mark(std::uint64_t n) {
-  std::lock_guard<std::mutex> lock {mutex_};
   TickIfNecessary();
-  count_ += n;
+  count_.fetch_add(n, std::memory_order_relaxed);
   m1_rate_.update(n);
   m5_rate_.update(n);
   m15_rate_.update(n);
@@ -194,13 +191,20 @@ void Meter::Impl::Mark(std::uint64_t n) {
 
 void Meter::Impl::Clear()
 {
-  std::lock_guard<std::mutex> lock {mutex_};
-  count_ = 0;
-  start_time_ = Clock::now();
-  last_tick_ = std::chrono::duration_cast<std::chrono::nanoseconds>(start_time_.time_since_epoch()).count();
+  bool expected = false;
+  while (!ticking_.compare_exchange_weak(expected, true, std::memory_order_acq_rel, std::memory_order_acquire)) {
+    expected = false;
+    std::this_thread::yield();
+  }
+
+  auto now = Now();
+  count_.store(0, std::memory_order_relaxed);
+  start_time_.store(now, std::memory_order_relaxed);
+  last_tick_.store(now, std::memory_order_relaxed);
   m1_rate_.clear();
   m5_rate_.clear();
   m15_rate_.clear();
+  ticking_.store(false, std::memory_order_release);
 }
 
 void Meter::Impl::Tick() {
@@ -211,16 +215,26 @@ void Meter::Impl::Tick() {
 
 
 void Meter::Impl::TickIfNecessary() {
-  // Only used internally, callers must ensure proper synchronization
-  auto old_tick = last_tick_.load();
-  auto new_tick = std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now().time_since_epoch()).count();
+  auto old_tick = last_tick_.load(std::memory_order_relaxed);
+  auto new_tick = Now();
   auto age = new_tick - old_tick;
   if (age > kTickInterval) {
-    last_tick_ = new_tick;
-    auto required_ticks = age / kTickInterval;
-    for (auto i = 0; i < required_ticks; i ++) {
-      Tick();
+    bool expected = false;
+    if (!ticking_.compare_exchange_strong(expected, true, std::memory_order_acq_rel, std::memory_order_acquire)) {
+      return;
     }
+
+    old_tick = last_tick_.load(std::memory_order_relaxed);
+    new_tick = Now();
+    age = new_tick - old_tick;
+    if (age > kTickInterval) {
+      auto required_ticks = age / kTickInterval;
+      for (auto i = 0; i < required_ticks; i ++) {
+        Tick();
+      }
+      last_tick_.store(new_tick, std::memory_order_release);
+    }
+    ticking_.store(false, std::memory_order_release);
   }
 }
 

--- a/src/medida/meter.cc
+++ b/src/medida/meter.cc
@@ -3,7 +3,7 @@
 //
 
 #include "medida/meter.h"
-#include <Tracy.hpp>
+#include "medida/tracy.h"
 
 #include <atomic>
 #include <mutex>

--- a/src/medida/stats/ckms.cc
+++ b/src/medida/stats/ckms.cc
@@ -250,20 +250,19 @@ void CKMS::compress() {
   // considered as `prev` for the following pair, and the error allowance is
   // computed from next's position in (and size of) the evolving vector.
   std::size_t const n = sample_.size();
-  std::vector<Item> out;
-  out.reserve(n);
+  std::size_t write = 0;
 
   Item prev = sample_[0];
   bool havePrev = true;
   std::size_t i = 1;
   while (i < n) {
-    Item const& next = sample_[i];
-    std::size_t evolvingSize = out.size() + 1 + (n - i);
+    Item next = sample_[i];
+    std::size_t evolvingSize = write + 1 + (n - i);
     if (prev.g + next.g + next.delta <=
-        allowableError(static_cast<int>(out.size() + 1), evolvingSize)) {
+        allowableError(static_cast<int>(write + 1), evolvingSize)) {
       Item folded = next;
       folded.g += prev.g;
-      out.push_back(folded);
+      sample_[write++] = folded;
       ++i;
       if (i < n) {
         prev = sample_[i];
@@ -272,15 +271,15 @@ void CKMS::compress() {
         havePrev = false;
       }
     } else {
-      out.push_back(prev);
+      sample_[write++] = prev;
       prev = next;
       ++i;
     }
   }
   if (havePrev) {
-    out.push_back(prev);
+    sample_[write++] = prev;
   }
-  sample_.swap(out);
+  sample_.erase(sample_.begin() + write, sample_.end());
 }
 
 } // namespace stats

--- a/src/medida/stats/ckms.cc
+++ b/src/medida/stats/ckms.cc
@@ -137,7 +137,10 @@ void CKMS::reset() {
 }
 
 double CKMS::allowableError(int rank) {
-  auto size = sample_.size();
+  return allowableError(rank, sample_.size());
+}
+
+double CKMS::allowableError(int rank, std::size_t size) const {
   double minError = size + 1;
 
   for (const auto& q : quantiles_.get()) {
@@ -169,30 +172,67 @@ bool CKMS::insertBatch() {
     ++count_;
   }
 
-  std::size_t idx = 0;
-  std::size_t item = idx++;
+  // Single-pass merge of the sorted buffer into the sorted sample. This is
+  // semantically identical to the historical version (which emplaced each
+  // value mid-vector, costing O(buffer * sample) element moves per batch and
+  // causing latency spikes on hot histograms), including its quirks:
+  //  - a value equal to an existing element is inserted right after the
+  //    first such element encountered by the forward scan;
+  //  - delta is computed from the insertion *position* in the evolving
+  //    vector and the evolving (pre-insertion) size, with delta = 0 only for
+  //    position 1 and the second-to-last position (position 0 falls through
+  //    to the general formula due to size_t underflow in `idx - 1 == 0`).
+  //
+  // Scan state: `cur` is the element the scan pointer rests on (either an
+  // original sample element or the most recently inserted value); elements
+  // before it are in `merged`; elements after it are sample_[s..n-1].
+  std::size_t const n = sample_.size();
+  std::vector<Item> merged;
+  merged.reserve(n + buffer_count_ - start);
+
+  Item cur = sample_[0];
+  std::size_t s = 1;
 
   for (std::size_t i = start; i < buffer_count_; ++i) {
     double v = buffer_[i];
-    while (idx < sample_.size() && sample_[item].value < v) {
-      item = idx++;
+    while (cur.value < v && s < n) {
+      merged.push_back(cur);
+      cur = sample_[s++];
     }
 
-    if (sample_[item].value > v) {
-      --idx;
+    // Pre-insertion size of the evolving vector: merged + cur + suffix.
+    std::size_t evolvingSize = merged.size() + 1 + (n - s);
+    std::size_t idx;
+    if (cur.value > v) {
+      // Insert before cur: cur (always an original sample element here,
+      // since previously inserted values are <= v) returns to the head of
+      // the unconsumed suffix.
+      idx = merged.size();
+      --s;
+    } else {
+      // cur.value <= v: insert right after cur. This covers both the
+      // equal-value case and the append-at-end case where the scan
+      // consumed the whole suffix.
+      merged.push_back(cur);
+      idx = merged.size();
     }
 
     int delta;
-    if (idx - 1 == 0 || idx + 1 == sample_.size()) {
+    if (idx - 1 == 0 || idx + 1 == evolvingSize) {
       delta = 0;
     } else {
-      delta = static_cast<int>(std::floor(allowableError(idx + 1))) + 1;
+      delta = static_cast<int>(std::floor(
+                  allowableError(static_cast<int>(idx + 1), evolvingSize))) +
+              1;
     }
 
-    sample_.emplace(sample_.begin() + idx, v, 1, delta);
+    cur = Item(v, 1, delta);
     count_++;
-    item = idx++;
   }
+
+  merged.push_back(cur);
+  merged.insert(merged.end(), sample_.begin() + s, sample_.end());
+  sample_.swap(merged);
 
   buffer_count_ = 0;
   return true;
@@ -203,20 +243,44 @@ void CKMS::compress() {
     return;
   }
 
-  std::size_t idx = 0;
-  std::size_t prev;
-  std::size_t next = idx++;
+  // Walk adjacent (prev, next) pairs, folding prev into next when the
+  // combined error stays within bounds. Semantically identical to the
+  // historical version (which did an O(n) vector::erase per fold),
+  // including its index bookkeeping quirks: a freshly folded item is not
+  // considered as `prev` for the following pair, and the error allowance is
+  // computed from next's position in (and size of) the evolving vector.
+  std::size_t const n = sample_.size();
+  std::vector<Item> out;
+  out.reserve(n);
 
-  while (idx < sample_.size()) {
-    prev = next;
-    next = idx++;
-
-    if (sample_[prev].g + sample_[next].g + sample_[next].delta <=
-        allowableError(idx - 1)) {
-      sample_[next].g += sample_[prev].g;
-      sample_.erase(sample_.begin() + prev);
+  Item prev = sample_[0];
+  bool havePrev = true;
+  std::size_t i = 1;
+  while (i < n) {
+    Item const& next = sample_[i];
+    std::size_t evolvingSize = out.size() + 1 + (n - i);
+    if (prev.g + next.g + next.delta <=
+        allowableError(static_cast<int>(out.size() + 1), evolvingSize)) {
+      Item folded = next;
+      folded.g += prev.g;
+      out.push_back(folded);
+      ++i;
+      if (i < n) {
+        prev = sample_[i];
+        ++i;
+      } else {
+        havePrev = false;
+      }
+    } else {
+      out.push_back(prev);
+      prev = next;
+      ++i;
     }
   }
+  if (havePrev) {
+    out.push_back(prev);
+  }
+  sample_.swap(out);
 }
 
 } // namespace stats

--- a/src/medida/stats/ckms.h
+++ b/src/medida/stats/ckms.h
@@ -50,6 +50,7 @@ class CKMS {
 
  private:
   double allowableError(int rank);
+  double allowableError(int rank, std::size_t size) const;
   bool insertBatch();
   void compress();
 

--- a/src/medida/stats/ckms_sample.cc
+++ b/src/medida/stats/ckms_sample.cc
@@ -25,6 +25,7 @@ class CKMSSample::Impl {
   std::uint64_t size(SystemClock::time_point timestamp);
   void Update(std::int64_t value);
   void Update(std::int64_t value, SystemClock::time_point timestamp);
+  void UpdateMany(const std::vector<std::int64_t>& values, SystemClock::time_point timestamp);
   Snapshot MakeSnapshot(uint64_t divisor = 1);
   Snapshot MakeSnapshot(SystemClock::time_point timestamp, uint64_t divisor = 1);
  private:
@@ -64,6 +65,14 @@ void CKMSSample::Update(std::int64_t value) {
 
 void CKMSSample::Update(std::int64_t value, SystemClock::time_point timestamp) {
   impl_->Update(value, timestamp);
+}
+
+void CKMSSample::UpdateMany(const std::vector<std::int64_t>& values) {
+  impl_->UpdateMany(values, SystemClock::now());
+}
+
+void CKMSSample::UpdateMany(const std::vector<std::int64_t>& values, SystemClock::time_point timestamp) {
+  impl_->UpdateMany(values, timestamp);
 }
 
 Snapshot CKMSSample::MakeSnapshot(uint64_t divisor) const {
@@ -156,6 +165,15 @@ void CKMSSample::Impl::Update(std::int64_t value, SystemClock::time_point timest
     std::lock_guard<std::mutex> lock{mutex_};
     if (AdvanceWindows(timestamp)) {
         cur_window_->insert(value);
+    }
+}
+
+void CKMSSample::Impl::UpdateMany(const std::vector<std::int64_t>& values, SystemClock::time_point timestamp) {
+    std::lock_guard<std::mutex> lock{mutex_};
+    if (AdvanceWindows(timestamp)) {
+        for (auto value : values) {
+            cur_window_->insert(value);
+        }
     }
 }
 

--- a/src/medida/stats/ckms_sample.h
+++ b/src/medida/stats/ckms_sample.h
@@ -50,6 +50,8 @@ class CKMSSample : public Sample {
   virtual std::uint64_t size(SystemClock::time_point timestamp) const;
   virtual void Update(std::int64_t value);
   virtual void Update(std::int64_t value, SystemClock::time_point timestamp);
+  virtual void UpdateMany(const std::vector<std::int64_t>& values) override;
+  virtual void UpdateMany(const std::vector<std::int64_t>& values, SystemClock::time_point timestamp);
   virtual Snapshot MakeSnapshot(uint64_t divisor = 1) const;
   virtual Snapshot MakeSnapshot(SystemClock::time_point timestamp, uint64_t divisor = 1) const;
  private:

--- a/src/medida/stats/ewma.cc
+++ b/src/medida/stats/ewma.cc
@@ -29,8 +29,8 @@ class EWMA::Impl {
   double getRate(std::chrono::nanoseconds duration = std::chrono::seconds {1}) const;
   void clear();
  private:
-  volatile bool initialized_;
-  volatile double rate_;
+  std::atomic<bool> initialized_;
+  std::atomic<double> rate_;
   std::atomic<std::int64_t> uncounted_;
   const double alpha_;
   const std::int64_t interval_nanos_;
@@ -98,9 +98,9 @@ EWMA::Impl::Impl(double alpha, std::chrono::nanoseconds interval)
 
 
 EWMA::Impl::Impl(Impl &other)
-    : initialized_    {other.initialized_},
-      rate_           {other.rate_},
-      uncounted_      {other.uncounted_.load()},
+    : initialized_    {other.initialized_.load(std::memory_order_relaxed)},
+      rate_           {other.rate_.load(std::memory_order_relaxed)},
+      uncounted_      {other.uncounted_.load(std::memory_order_relaxed)},
       alpha_          {other.alpha_},
       interval_nanos_ {other.interval_nanos_} {
 }
@@ -111,31 +111,32 @@ EWMA::Impl::~Impl() {
 
 
 void EWMA::Impl::update(std::int64_t n) {
-  uncounted_ += n;
+  uncounted_.fetch_add(n, std::memory_order_relaxed);
 }
 
 
 void EWMA::Impl::tick() {
-  double count = uncounted_.exchange(0);
+  double count = uncounted_.exchange(0, std::memory_order_relaxed);
   auto instantRate = count / interval_nanos_;
-  if (initialized_) {
-    rate_ += (alpha_ * (instantRate - rate_));
+  if (initialized_.load(std::memory_order_relaxed)) {
+    auto rate = rate_.load(std::memory_order_relaxed);
+    rate_.store(rate + (alpha_ * (instantRate - rate)), std::memory_order_relaxed);
   } else {
-    rate_ = instantRate;
-    initialized_ = true;
+    rate_.store(instantRate, std::memory_order_relaxed);
+    initialized_.store(true, std::memory_order_relaxed);
   }
 }
 
 
 double EWMA::Impl::getRate(std::chrono::nanoseconds duration) const {
-  return rate_ * duration.count();
+  return rate_.load(std::memory_order_relaxed) * duration.count();
 }
 
 void EWMA::Impl::clear()
 {
-  initialized_ = false;
-  rate_ = 0.0;
-  uncounted_ = 0;
+  initialized_.store(false, std::memory_order_relaxed);
+  rate_.store(0.0, std::memory_order_relaxed);
+  uncounted_.store(0, std::memory_order_relaxed);
 }
 
 } // namespace stats

--- a/src/medida/stats/sample.h
+++ b/src/medida/stats/sample.h
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <vector>
 
 #include "medida/stats/snapshot.h"
 
@@ -19,6 +20,13 @@ public:
   virtual void Clear() = 0;
   virtual std::uint64_t size() const = 0;
   virtual void Update(std::int64_t value) = 0;
+  // Bulk update; implementations may amortize per-update overhead (locking,
+  // clock reads) over the whole batch.
+  virtual void UpdateMany(const std::vector<std::int64_t>& values) {
+    for (auto value : values) {
+      Update(value);
+    }
+  }
   virtual Snapshot MakeSnapshot(uint64_t divisor = 1) const = 0;
 };
 

--- a/src/medida/timer.cc
+++ b/src/medida/timer.cc
@@ -3,7 +3,7 @@
 //
 
 #include "medida/timer.h"
-#include <Tracy.hpp>
+#include "medida/tracy.h"
 
 #include "medida/histogram.h"
 #include "medida/meter.h"

--- a/src/medida/timer.cc
+++ b/src/medida/timer.cc
@@ -35,6 +35,7 @@ class Timer::Impl {
   std::chrono::nanoseconds duration_unit() const;
   void Clear();
   void Update(std::chrono::nanoseconds duration);
+  void UpdateMany(const std::vector<std::int64_t>& durations_ns);
   TimerContext TimeScope();
   void Time(std::function<void()>);
  private:
@@ -157,6 +158,12 @@ void Timer::Update(std::chrono::nanoseconds duration) {
 }
 
 
+void Timer::UpdateMany(const std::vector<std::int64_t>& durations_ns) {
+    ZoneScoped;
+    impl_->UpdateMany(durations_ns);
+}
+
+
 stats::Snapshot Timer::GetSnapshot() const {
     ZoneScoped;
     return impl_->GetSnapshot();
@@ -275,6 +282,28 @@ void Timer::Impl::Update(std::chrono::nanoseconds duration) {
   if (count >= 0) {
     histogram_.Update(count);
     meter_.Mark();
+  }
+}
+
+
+void Timer::Impl::UpdateMany(const std::vector<std::int64_t>& durations_ns) {
+  bool allNonNegative = true;
+  for (auto d : durations_ns) {
+    if (d < 0) {
+      allNonNegative = false;
+      break;
+    }
+  }
+  if (allNonNegative) {
+    if (!durations_ns.empty()) {
+      histogram_.UpdateMany(durations_ns);
+      meter_.Mark(durations_ns.size());
+    }
+  } else {
+    // Rare: fall back to filtering out negative durations one by one.
+    for (auto d : durations_ns) {
+      Update(std::chrono::nanoseconds(d));
+    }
   }
 }
 

--- a/src/medida/timer.h
+++ b/src/medida/timer.h
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <vector>
 
 #include "medida/metered_interface.h"
 #include "medida/metric_interface.h"
@@ -42,6 +43,9 @@ class Timer : public MetricInterface, MeteredInterface, SamplingInterface, Summa
   std::chrono::nanoseconds duration_unit() const;
   void Clear();
   void Update(std::chrono::nanoseconds duration);
+  // Record a batch of durations (expressed in nanoseconds) with a single
+  // lock acquisition; equivalent to calling Update on each duration.
+  void UpdateMany(const std::vector<std::int64_t>& durations_ns);
   TimerContext TimeScope();
   void Time(std::function<void()>);
  private:

--- a/src/medida/timer_context.cc
+++ b/src/medida/timer_context.cc
@@ -2,7 +2,7 @@
 // Copyright (c) 2012 Daniel Lundin
 //
 
-#include <Tracy.hpp>
+#include "medida/tracy.h"
 #include <stdexcept>
 
 #include "medida/timer_context.h"

--- a/src/medida/tracy.h
+++ b/src/medida/tracy.h
@@ -1,0 +1,15 @@
+// Optional Tracy integration wrapper.
+#ifndef MEDIDA_TRACY_H_
+#define MEDIDA_TRACY_H_
+
+#if defined(__has_include)
+#if __has_include(<Tracy.hpp>)
+#include <Tracy.hpp>
+#endif
+#endif
+
+#ifndef ZoneScoped
+#define ZoneScoped ((void)0)
+#endif
+
+#endif // MEDIDA_TRACY_H_

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Build gtest from source
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 add_subdirectory (gtest-1.6.0)
 include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
+include_directories(${medida_SOURCE_DIR}/src)
 
 set(test_sources
   test_counter.cc
@@ -9,7 +11,6 @@ set(test_sources
   test_metric_name.cc
   test_metrics_registry.cc
   test_timer.cc
-  reporting/test_collectd_reporter.cc
   reporting/test_console_reporter.cc
   reporting/test_json_reporter.cc
   stats/test_ckms.cc
@@ -19,6 +20,12 @@ set(test_sources
   stats/test_snapshot.cc
   stats/test_uniform_sample.cc
 )
+
+if(MEDIDA_WITH_COLLECTD_REPORTER AND NOT WIN32)
+  list(APPEND test_sources
+    reporting/test_collectd_reporter.cc
+  )
+endif()
 
 add_executable(test-medida ${test_sources})
 

--- a/test/stats/test_ckms_sample.cc
+++ b/test/stats/test_ckms_sample.cc
@@ -44,7 +44,7 @@ TEST(CKMSSampleTest, aThreeDifferentValues) {
 TEST(CKMSSampleTest, aCKMSSnapshotTestCurrentWindow) {
   CKMSSample sample;
 
-  auto t = medida::Clock::time_point();
+  auto t = medida::SystemClock::time_point();
 
   // [0 seconds, 30 seconds) contains {1, 1, ..., 1}. (30 of them)
   // [30 seconds, 60 seconds) contains {2, 2, ..., 2}. (15 of them)
@@ -67,7 +67,7 @@ TEST(CKMSSampleTest, aCKMSSnapshotTestCurrentWindow) {
 TEST(CKMSSampleTest, aCKMSSnapshotTestNextWindow) {
   CKMSSample sample;
 
-  auto t = medida::Clock::time_point();
+  auto t = medida::SystemClock::time_point();
 
   // [0 seconds, 30 seconds) contains {1, 1, ..., 1}. (30 of them)
   for (auto i = 0; i < 30; i++) {
@@ -87,7 +87,7 @@ TEST(CKMSSampleTest, aCKMSSnapshotTestNextWindow) {
 TEST(CKMSSampleTest, aCKMSSnapshotTestFuture) {
   CKMSSample sample;
 
-  auto t = medida::Clock::time_point();
+  auto t = medida::SystemClock::time_point();
 
   // [0 seconds, 30 seconds) contains {1, 1, ..., 1}. (30 of them)
   for (auto i = 0; i < 30; i++) {
@@ -107,7 +107,7 @@ TEST(CKMSSampleTest, aCKMSSnapshotTestFuture) {
 TEST(CKMSSampleTest, aCKMSUpdateWithHugeGap) {
   CKMSSample sample;
 
-  auto t = medida::Clock::time_point();
+  auto t = medida::SystemClock::time_point();
 
   for (auto i = 0; i < 10; i++) {
     sample.Update(1, t);
@@ -129,7 +129,7 @@ TEST(CKMSSampleTest, aCKMSUpdateWithHugeGap) {
 TEST(CKMSSampleTest, aSpikyInputs) {
   CKMSSample sample;
 
-  auto t = medida::Clock::now();
+  auto t = medida::SystemClock::now();
 
   auto const size = 100000;
   for (auto i = 0; i < 5; i++) {

--- a/test/stats/test_ewma.cc
+++ b/test/stats/test_ewma.cc
@@ -4,6 +4,12 @@
 
 #include "medida/stats/ewma.h"
 
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <thread>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 using namespace medida::stats;
@@ -137,4 +143,56 @@ TEST(EWMATest, rateDefaultDurationIsOneSecond) {
   EXPECT_NEAR(0.6, ewma.getRate(), 1e-6);
   EXPECT_NEAR(36.0, ewma.getRate(std::chrono::minutes(1)), 1e-6);
   EXPECT_NEAR(2160.0, ewma.getRate(std::chrono::hours(1)), 1e-6);
+}
+
+
+TEST(EWMATest, concurrentOperationsStayFinite) {
+  auto ewma = EWMA::oneMinuteEWMA();
+  std::atomic<bool> valid {true};
+  std::vector<std::thread> threads;
+
+  for (auto i = 0; i < 4; i++) {
+    threads.emplace_back([&]() {
+      for (auto j = 0; j < 10000; j++) {
+        ewma.update(1);
+        if (j % 500 == 0) {
+          std::this_thread::sleep_for(std::chrono::microseconds(100));
+        }
+      }
+    });
+  }
+
+  threads.emplace_back([&]() {
+    for (auto i = 0; i < 1000; i++) {
+      ewma.tick();
+      if (i % 50 == 0) {
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
+      }
+    }
+  });
+
+  threads.emplace_back([&]() {
+    for (auto i = 0; i < 1000; i++) {
+      auto rate = ewma.getRate();
+      if (!std::isfinite(rate) || rate < 0.0) {
+        valid.store(false);
+      }
+      if (i % 50 == 0) {
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
+      }
+    }
+  });
+
+  threads.emplace_back([&]() {
+    for (auto i = 0; i < 100; i++) {
+      ewma.clear();
+      std::this_thread::sleep_for(std::chrono::microseconds(100));
+    }
+  });
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  EXPECT_TRUE(valid.load());
 }

--- a/test/stats/test_exp_decay_sample.cc
+++ b/test/stats/test_exp_decay_sample.cc
@@ -103,8 +103,13 @@ TEST(ExpDecaySampleTest, longPeriodsOfInactivityShouldNotCorruptSamplingState) {
   }
   EXPECT_EQ(10, sample.size());
 
-  for (auto& v : sample.MakeSnapshot().getValues()) {
+  int newSamples = 0;
+  auto snapshot = sample.MakeSnapshot();
+  for (auto& v : snapshot.getValues()) {
     EXPECT_LE(v, 4000.0);
-    EXPECT_GE(v, 3000.0);
+    newSamples += v >= 3000.0;
   }
+  // Sometimes the 2000 value is still in the snapshot due to the randomness 
+  // of the sampling.
+  EXPECT_GE(newSamples, snapshot.getValues().size() - 1);
 }

--- a/test/test_histogram.cc
+++ b/test/test_histogram.cc
@@ -57,23 +57,46 @@ TEST(HistogramTest, ckmsWindowSize) {
   auto& histogram1 = r1.NewHistogram({"a", "b", "c"}, SamplingInterface::kCKMS);
   auto& histogram2 = r2.NewHistogram({"a", "b", "c"}, SamplingInterface::kCKMS);
 
-  histogram1.Update(123);
-  histogram2.Update(123);
+  auto updateValues = [&]() {
+    histogram1.Update(123);
+    histogram2.Update(123);
+  };
+
+  updateValues();
 
   // CKMS reports the previous window.
   // The value 123 was added in the current window,
   // so we shouldn't report anything yet.
-  EXPECT_EQ(0, histogram1.GetSnapshot().size());
-  EXPECT_EQ(0, histogram2.GetSnapshot().size());
+  EXPECT_EQ(0u, histogram1.GetSnapshot().size());
+  EXPECT_EQ(0u, histogram2.GetSnapshot().size());
 
-  std::this_thread::sleep_for(std::chrono::seconds(1));
+  auto snapshot1_size = std::uint64_t {0};
+  for (auto attempt = 0; attempt < 3 && snapshot1_size == 0; attempt++) {
+    if (attempt != 0) {
+      updateValues();
+    }
+
+    auto deadline = Clock::now() + std::chrono::seconds(2);
+    while (true) {
+      auto snapshot1 = histogram1.GetSnapshot();
+      auto snapshot2 = histogram2.GetSnapshot();
+      // histogram2 snapshot will always be empty
+      EXPECT_EQ(0u, snapshot2.size());
+
+      snapshot1_size = snapshot1.size();
+      if (snapshot1_size != 0 || Clock::now() >= deadline) {
+        break;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
 
   // Since r1 uses 1 second as the window size,
-  // the value 123 must be in the previous window now.
+  // the value 123 must eventually be in the previous window.
   // r1 uses 2000000000 seconds (= approx. 63 years) as the window size,
   // so the value 123 must not be in the current window yet.
-  EXPECT_EQ(1, histogram1.GetSnapshot().size());
-  EXPECT_EQ(0, histogram2.GetSnapshot().size());
+  EXPECT_NE(0u, snapshot1_size);
+  EXPECT_EQ(0u, histogram2.GetSnapshot().size());
 }
 
 TEST(HistogramTest, ckmsMetrics) {

--- a/test/test_histogram.cc
+++ b/test/test_histogram.cc
@@ -4,8 +4,12 @@
 
 #include "medida/histogram.h"
 
+#include <atomic>
+#include <chrono>
+#include <cmath>
 #include <gtest/gtest.h>
 #include <thread>
+#include <vector>
 
 #include "medida/metrics_registry.h"
 
@@ -114,4 +118,72 @@ TEST(HistogramTest, ckmsMetrics) {
   EXPECT_NEAR(2.1602468994693, h.std_dev(), 1e-6);
   EXPECT_EQ(28, h.sum());
   EXPECT_EQ(7, h.count());
+}
+
+TEST(HistogramTest, updateManyIsSafeWithConcurrentReaders) {
+  MetricsRegistry registry {};
+  auto& histogram = registry.NewHistogram({"a", "b", "c"}, SamplingInterface::kUniform);
+  const auto numThreads = 8;
+  const auto batchesPerThread = 128;
+  const auto valuesPerBatch = 16;
+  const auto expectedCount = numThreads * batchesPerThread * valuesPerBatch;
+  const auto expectedSum = expectedCount * (expectedCount + 1) / 2;
+  std::atomic<bool> writersDone {false};
+  bool observedInvalidState {false};
+  bool observedNonEmptyHistogram {false};
+  std::uint64_t readerObservations {0};
+  std::vector<std::thread> threads;
+
+  auto reader = std::thread {[&]() {
+    while (!writersDone.load()) {
+      auto count = histogram.count();
+      auto sum = histogram.sum();
+      auto min = histogram.min();
+      auto max = histogram.max();
+      auto mean = histogram.mean();
+      auto stdDev = histogram.std_dev();
+      auto snapshot = histogram.GetSnapshot();
+      if (count != 0) {
+        observedNonEmptyHistogram = true;
+        if (sum < count || max < min || !std::isfinite(mean) ||
+            !std::isfinite(stdDev) || snapshot.size() > expectedCount) {
+          observedInvalidState = true;
+        }
+      }
+      readerObservations++;
+      std::this_thread::sleep_for(std::chrono::microseconds(100));
+    }
+  }};
+
+  for (auto threadIndex = 0; threadIndex < numThreads; threadIndex++) {
+    threads.emplace_back([&, threadIndex]() {
+      for (auto batchIndex = 0; batchIndex < batchesPerThread; batchIndex++) {
+        std::vector<std::int64_t> values;
+        values.reserve(valuesPerBatch);
+        for (auto valueIndex = 0; valueIndex < valuesPerBatch; valueIndex++) {
+          values.push_back(threadIndex * batchesPerThread * valuesPerBatch +
+                           batchIndex * valuesPerBatch + valueIndex + 1);
+        }
+        histogram.UpdateMany(values);
+        if ((batchIndex + threadIndex) % 2 == 0) {
+          std::this_thread::sleep_for(std::chrono::microseconds(100));
+        }
+      }
+    });
+  }
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  writersDone.store(true);
+  reader.join();
+
+  EXPECT_GE(readerObservations, 10u);
+  EXPECT_TRUE(observedNonEmptyHistogram);
+  EXPECT_FALSE(observedInvalidState);
+  EXPECT_EQ(expectedCount, histogram.count());
+  EXPECT_NEAR(1.0, histogram.min(), 0.001);
+  EXPECT_NEAR(expectedCount, histogram.max(), 0.001);
+  EXPECT_NEAR(expectedCount / 2.0 + 0.5, histogram.mean(), 0.001);
+  EXPECT_NEAR(expectedSum, histogram.sum(), 0.1);
 }

--- a/test/test_meter.cc
+++ b/test/test_meter.cc
@@ -4,7 +4,10 @@
 
 #include "medida/meter.h"
 
+#include <atomic>
+#include <cmath>
 #include <thread>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -16,7 +19,7 @@ using namespace medida;
 TEST(MeterTest, aBlankMeter) {
   Meter meter {"things"};
   EXPECT_EQ("things", meter.event_type());
-  EXPECT_EQ(0, meter.count());
+  EXPECT_EQ(0u, meter.count());
   EXPECT_NEAR(0.0, meter.mean_rate(), 0.001);
 }
 
@@ -24,7 +27,7 @@ TEST(MeterTest, aBlankMeter) {
 TEST(MeterTest, createFromRegistry) {
   MetricsRegistry registry {};
   auto& meter = registry.NewMeter({"a", "b", "c"}, "things");
-  EXPECT_EQ(0, meter.count());
+  EXPECT_EQ(0u, meter.count());
   EXPECT_EQ("things", meter.event_type());
 }
 
@@ -32,7 +35,7 @@ TEST(MeterTest, createFromRegistry) {
 TEST(MeterTest, aMeterWithThreeEvents) {
   Meter meter {"things"};
   meter.Mark(3);
-  EXPECT_EQ(3, meter.count());
+  EXPECT_EQ(3u, meter.count());
 }
 
 
@@ -42,7 +45,94 @@ TEST(MeterTest, meterTiming) {
     meter.Mark();
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
-  EXPECT_EQ(10, meter.count());
-  EXPECT_NEAR(10, meter.mean_rate(), 0.1);
+  EXPECT_EQ(10u, meter.count());
+  EXPECT_NEAR(10, meter.mean_rate(), 0.5);
+}
+
+
+TEST(MeterTest, concurrentMarkAndRead) {
+  Meter meter {"things"};
+  std::atomic<bool> done {false};
+  std::atomic<bool> valid {true};
+  std::vector<std::thread> threads;
+
+  for (auto i = 0; i < 4; i++) {
+    threads.emplace_back([&]() {
+      for (auto j = 0; j < 10000; j++) {
+        meter.Mark();
+      }
+    });
+  }
+
+  std::thread reader {[&]() {
+    while (!done.load()) {
+      auto mean_rate = meter.mean_rate();
+      auto one_minute_rate = meter.one_minute_rate();
+      auto five_minute_rate = meter.five_minute_rate();
+      auto fifteen_minute_rate = meter.fifteen_minute_rate();
+      if (!std::isfinite(mean_rate) || mean_rate < 0.0 ||
+          !std::isfinite(one_minute_rate) || one_minute_rate < 0.0 ||
+          !std::isfinite(five_minute_rate) || five_minute_rate < 0.0 ||
+          !std::isfinite(fifteen_minute_rate) || fifteen_minute_rate < 0.0) {
+        valid.store(false);
+      }
+    }
+  }};
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  done.store(true);
+  reader.join();
+
+  EXPECT_TRUE(valid.load());
+  EXPECT_EQ(40000u, meter.count());
+}
+
+
+TEST(MeterTest, concurrentClearAndMark) {
+  Meter meter {"things"};
+  std::atomic<bool> done {false};
+  std::atomic<bool> valid {true};
+  std::vector<std::thread> threads;
+
+  for (auto i = 0; i < 4; i++) {
+    threads.emplace_back([&]() {
+      while (!done.load()) {
+        meter.Mark();
+      }
+    });
+  }
+
+  std::thread reader {[&]() {
+    while (!done.load()) {
+      auto mean_rate = meter.mean_rate();
+      auto one_minute_rate = meter.one_minute_rate();
+      auto five_minute_rate = meter.five_minute_rate();
+      auto fifteen_minute_rate = meter.fifteen_minute_rate();
+      if (!std::isfinite(mean_rate) || mean_rate < 0.0 ||
+          !std::isfinite(one_minute_rate) || one_minute_rate < 0.0 ||
+          !std::isfinite(five_minute_rate) || five_minute_rate < 0.0 ||
+          !std::isfinite(fifteen_minute_rate) || fifteen_minute_rate < 0.0) {
+        valid.store(false);
+      }
+    }
+  }};
+
+  for (auto i = 0; i < 100; i++) {
+    meter.Clear();
+  }
+  done.store(true);
+
+  reader.join();
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  meter.Clear();
+  EXPECT_TRUE(valid.load());
+  EXPECT_EQ(0u, meter.count());
+  EXPECT_NEAR(0.0, meter.mean_rate(), 0.001);
 }
 

--- a/test/test_meter.cc
+++ b/test/test_meter.cc
@@ -5,6 +5,7 @@
 #include "medida/meter.h"
 
 #include <atomic>
+#include <chrono>
 #include <cmath>
 #include <thread>
 #include <vector>
@@ -134,5 +135,71 @@ TEST(MeterTest, concurrentClearAndMark) {
   EXPECT_TRUE(valid.load());
   EXPECT_EQ(0u, meter.count());
   EXPECT_NEAR(0.0, meter.mean_rate(), 0.001);
+}
+
+TEST(MeterTest, concurrentOperationsStayFinite) {
+  Meter meter {"things"};
+  bool valid {true};
+  bool observed_non_zero_count {false};
+  std::uint64_t observations {0};
+  std::vector<std::thread> threads;
+
+  for (auto i = 0; i < 4; i++) {
+    threads.emplace_back([&]() {
+      for (auto j = 0; j < 10000; j++) {
+        meter.Mark();
+        if (j % 500 == 0) {
+          std::this_thread::sleep_for(std::chrono::microseconds(100));
+        }
+      }
+    });
+  }
+
+  threads.emplace_back([&]() {
+    for (auto i = 0; i < 1000; i++) {
+      meter.Mark(3);
+      if (i % 50 == 0) {
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
+      }
+    }
+  });
+
+  threads.emplace_back([&]() {
+    for (auto i = 0; i < 1000; i++) {
+      auto count = meter.count();
+      auto mean_rate = meter.mean_rate();
+      auto one_minute_rate = meter.one_minute_rate();
+      auto five_minute_rate = meter.five_minute_rate();
+      auto fifteen_minute_rate = meter.fifteen_minute_rate();
+      if (!std::isfinite(mean_rate) || mean_rate < 0.0 ||
+          !std::isfinite(one_minute_rate) || one_minute_rate < 0.0 ||
+          !std::isfinite(five_minute_rate) || five_minute_rate < 0.0 ||
+          !std::isfinite(fifteen_minute_rate) || fifteen_minute_rate < 0.0) {
+        valid = false;
+      }
+      if (count != 0) {
+        observed_non_zero_count = true;
+      }
+      observations++;
+      if (i % 50 == 0) {
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
+      }
+    }
+  });
+
+  threads.emplace_back([&]() {
+    for (auto i = 0; i < 100; i++) {
+      meter.Clear();
+      std::this_thread::sleep_for(std::chrono::microseconds(100));
+    }
+  });
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  EXPECT_NE(0u, observations);
+  EXPECT_TRUE(observed_non_zero_count);
+  EXPECT_TRUE(valid);
 }
 

--- a/test/test_timer.cc
+++ b/test/test_timer.cc
@@ -4,6 +4,7 @@
 
 #include "medida/timer.h"
 
+#include <functional>
 #include <iostream>
 #include <thread>
 
@@ -57,21 +58,44 @@ TEST_F(TimerTest, aBlankTimer) {
   EXPECT_EQ(0, snapshot.size());
 }
 
+// Take a snapshot of the next non-empty window (since window is based on the
+// wall clock second bounds, the exact time to wait is non-deterministic).
+stats::Snapshot takeSnapshot(Timer& timer, std::function<void()> repopulate = {}) {
+  for (auto attempt = 0; attempt < 3; attempt++) {
+    if (attempt != 0 && repopulate) {
+      repopulate();
+    }
+
+    auto deadline = Clock::now() + std::chrono::seconds(2);
+    while (true) {
+      auto snapshot = timer.GetSnapshot();
+      if (snapshot.size() != 0 || Clock::now() >= deadline) {
+        if (snapshot.size() != 0 || !repopulate) {
+          return snapshot;
+        }
+        break;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
+
+  return timer.GetSnapshot();
+}
 
 TEST_F(TimerTest, timingASeriesOfEvents) {
   // As CKMS isn't very accurate when there's very few samples,
   // we will use for loops to add each value several times.
-  for (int i = 0; i < 10; i++) {
-    timer.Update(std::chrono::milliseconds(10));
-    timer.Update(std::chrono::milliseconds(20));
-    timer.Update(std::chrono::milliseconds(20));
-    timer.Update(std::chrono::milliseconds(30));
-    timer.Update(std::chrono::milliseconds(40));
-  }
+  auto updateValues = [&]() {
+    for (int i = 0; i < 10; i++) {
+      timer.Update(std::chrono::milliseconds(10));
+      timer.Update(std::chrono::milliseconds(20));
+      timer.Update(std::chrono::milliseconds(20));
+      timer.Update(std::chrono::milliseconds(30));
+      timer.Update(std::chrono::milliseconds(40));
+    }
+  };
 
-  // Wait for 1 second so that we're in the next window
-  // and CKMSSample reports {10, 20, ..., 50}.
-  std::this_thread::sleep_for(std::chrono::seconds(1));
+  updateValues();
 
   EXPECT_EQ(50, timer.count());
   EXPECT_NEAR(10.0, timer.min(), 0.001);
@@ -79,7 +103,9 @@ TEST_F(TimerTest, timingASeriesOfEvents) {
   EXPECT_NEAR(24.0, timer.mean(), 0.001);
   EXPECT_NEAR(10.301575, timer.std_dev(), 0.001);
 
-  auto snapshot = timer.GetSnapshot();
+
+  auto snapshot = takeSnapshot(timer, updateValues);
+  ASSERT_NE(0u, snapshot.size());
   EXPECT_NEAR(20.0, snapshot.getMedian(), 0.001);
   EXPECT_NEAR(30.0, snapshot.get75thPercentile(), 0.001);
   EXPECT_NEAR(40, snapshot.get99thPercentile(), 0.001);
@@ -90,9 +116,13 @@ TEST_F(TimerTest, timingASeriesOfEvents) {
 TEST_F(TimerTest, timingASeriesOfShortEvents) {
   // This test makes sure that the calculation and casting are done correctly,
   // and prevents short events from being ignored as rounding errors.
-  for (int i = 0; i < 10; i++) {
-    timer.Update(std::chrono::nanoseconds(1));
-  }
+  auto updateValues = [&]() {
+    for (int i = 0; i < 10; i++) {
+      timer.Update(std::chrono::nanoseconds(1));
+    }
+  };
+
+  updateValues();
 
   EXPECT_EQ(10, timer.count());
   EXPECT_NEAR(1e-6, timer.min(), 1e-9);
@@ -100,11 +130,7 @@ TEST_F(TimerTest, timingASeriesOfShortEvents) {
   EXPECT_NEAR(1e-6, timer.mean(), 1e-9);
   EXPECT_NEAR(0, timer.std_dev(), 1e-9);
 
-  // Wait for 1 second so that we're in the next window
-  // and CKMSSample reports {1 nano second, 1 nano second, ..., 1 nano second}.
-  std::this_thread::sleep_for(std::chrono::seconds(1));
-
-  auto snapshot = timer.GetSnapshot();
+  auto snapshot = takeSnapshot(timer, updateValues);
   EXPECT_NEAR(1e-6, snapshot.getMedian(), 1e-9);
   EXPECT_NEAR(1e-6, snapshot.get75thPercentile(), 1e-9);
   EXPECT_NEAR(1e-6, snapshot.get99thPercentile(), 1e-9);
@@ -115,7 +141,6 @@ TEST_F(TimerTest, timingASeriesOfShortEvents) {
 TEST_F(TimerTest, timingVariantValues) {
   timer.Update(std::chrono::nanoseconds(9223372036854775807));  // INT64_MAX
   timer.Update(std::chrono::nanoseconds(0));
-  std::this_thread::sleep_for(std::chrono::seconds(1));
   EXPECT_NEAR(6.521908912666392E12, timer.std_dev(), 0.001);
 }
 
@@ -129,10 +154,9 @@ TEST_F(TimerTest, timerTimeScope) {
     auto t = timer.TimeScope();
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
   }
-  // Wait till we get to the next window so {100, 200} will be reported.
-  std::this_thread::sleep_for(std::chrono::seconds(1));
   EXPECT_EQ(2, timer.count());
-  EXPECT_NEAR(150.0, timer.mean(), 0.5);
+
+  EXPECT_GE(timer.mean(), 150.0);
 }
 
 
@@ -142,11 +166,9 @@ void my_func() {
 
 
 TEST_F(TimerTest, timerTimeFunction) {
-  timer.Time(my_func);
-  // Wait till we get to the next window.
-  std::this_thread::sleep_for(std::chrono::seconds(1));
+  timer.Time(my_func);  
   EXPECT_EQ(1, timer.count());
-  EXPECT_NEAR(100.0, timer.mean(), 0.5);
+  EXPECT_GE(timer.mean(), 100.0);
 }
 
 
@@ -154,8 +176,6 @@ TEST_F(TimerTest, timerTimeLambda) {
   timer.Time([]() {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   });
-  // Wait till we get to the next window.
-  std::this_thread::sleep_for(std::chrono::seconds(1));
   EXPECT_EQ(1, timer.count());
-  EXPECT_NEAR(100.0, timer.mean(), 1.0);
+  EXPECT_GE(timer.mean(), 100.0);
 }


### PR DESCRIPTION
This includes all the changes that were necessary to reduce the negative impact of metrics in Core apply path from over +~100% to +~2-8%. Likely this could be pushed further, but for now the improvement seems good enough to just merge it and start benefitting from the improvements. I also expect this to have some positive impact on Core overall, though it might be too small to be visible.

The gist of the changes:

- A bunch of build & test fixes, mostly reducing flakiness to make sure that the tests are green both before and after the changes
- Make Meter lock-free, use atomics instead
- Improve CKMS implementation by using linear algorithms instead of quadratic ones
- Expose methods for flushing batches of metrics (very useful for the apply stage which really needs just a single update per ledger)