### PR TITLE
Add fast/small log-histogram sample class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fno-diagnostics-show-option -Wall -Wextra -pedantic -Wno-long-long -Wno-deprecated -fno-strict-aliasing")
 endif()
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
@@ -43,6 +43,7 @@ set(medida_SOURCES
   src/medida/stats/sliding_window_sample.cc
   src/medida/stats/ckms.cc
   src/medida/stats/ckms_sample.cc
+  src/medida/stats/log_histogram_sample.cc
   src/medida/buckets.cc
   src/medida/counter.cc
   src/medida/meter.cc
@@ -92,6 +93,7 @@ set(medida_HEADERS
   src/medida/stats/uniform_sample.h
   src/medida/stats/ckms.h
   src/medida/stats/ckms_sample.h
+  src/medida/stats/log_histogram_sample.h
 )
 
 ## Dependencies
@@ -166,6 +168,7 @@ install(FILES
   src/medida/stats/sliding_window_sample.h
   src/medida/stats/ckms.h
   src/medida/stats/ckms_sample.h
+  src/medida/stats/log_histogram_sample.h
   src/medida/stats/sample.h
   src/medida/stats/snapshot.h
   src/medida/stats/uniform_sample.h

--- a/src/medida/histogram.cc
+++ b/src/medida/histogram.cc
@@ -14,6 +14,7 @@
 #include "medida/stats/uniform_sample.h"
 #include "medida/stats/sliding_window_sample.h"
 #include "medida/stats/ckms_sample.h"
+#include "medida/stats/log_histogram_sample.h"
 
 namespace medida {
 
@@ -154,6 +155,8 @@ Histogram::Impl::Impl(SampleType sample_type, std::chrono::seconds ckms_window_s
                                                                             kDefaultWindowTime));
   } else if (sample_type == kCKMS) {
     sample_ = std::unique_ptr<stats::Sample>(new stats::CKMSSample(ckms_window_size));
+  } else if (sample_type == kLogHistogram) {
+    sample_ = std::unique_ptr<stats::Sample>(new stats::LogHistogramSample(ckms_window_size));
   } else {
       throw std::invalid_argument("invalid sample_type");
   }

--- a/src/medida/sampling_interface.h
+++ b/src/medida/sampling_interface.h
@@ -11,7 +11,7 @@ namespace medida {
 
 class SamplingInterface {
 public:
-  enum SampleType { kUniform, kBiased, kSliding, kCKMS };
+  enum SampleType { kUniform, kBiased, kSliding, kCKMS, kLogHistogram };
   virtual ~SamplingInterface() {};
   virtual stats::Snapshot GetSnapshot() const = 0;
 };

--- a/src/medida/stats/log_histogram_sample.cc
+++ b/src/medida/stats/log_histogram_sample.cc
@@ -1,0 +1,415 @@
+// Copyright 2026 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "medida/stats/log_histogram_sample.h"
+
+#include <atomic>
+#include <bit>
+#include <cstddef>
+#include <limits>
+#include <stdexcept>
+#include <thread>
+#include <type_traits>
+
+#ifdef __linux__
+#include <ctime>
+#endif
+
+namespace medida {
+namespace stats {
+
+namespace {
+
+static std::int64_t const kInvalidWindow = std::numeric_limits<std::int64_t>::min();
+static std::int64_t const kPreparingWindow = kInvalidWindow + 1;
+
+std::size_t SubBucketBits(std::size_t buckets_per_level) {
+  if (!std::has_single_bit(buckets_per_level)) {
+    throw std::invalid_argument("buckets_per_level must be a power of two");
+  }
+  return static_cast<std::size_t>(std::bit_width(buckets_per_level) - 1);
+}
+
+std::uint64_t Magnitude(std::int64_t value) {
+  if (value >= 0) {
+    return static_cast<std::uint64_t>(value);
+  }
+  if (value == std::numeric_limits<std::int64_t>::min()) {
+    return std::uint64_t{1} << 63;
+  }
+  return static_cast<std::uint64_t>(-value);
+}
+
+std::size_t FloorLog2(std::uint64_t value) {
+  return static_cast<std::size_t>(std::numeric_limits<std::uint64_t>::digits -
+                                  1 - std::countl_zero(value));
+}
+
+std::size_t LevelsForMaxAbsoluteValue(std::uint64_t max_absolute_value) {
+  if (max_absolute_value == 0) {
+    throw std::invalid_argument("max_absolute_value must be positive");
+  }
+  return FloorLog2(max_absolute_value) + 1;
+}
+
+SystemClock::time_point CoarseNow() {
+#ifdef __linux__
+  struct timespec ts;
+  clock_gettime(CLOCK_REALTIME_COARSE, &ts);
+  return SystemClock::time_point(std::chrono::seconds(ts.tv_sec) +
+                                 std::chrono::nanoseconds(ts.tv_nsec));
+#else
+  return SystemClock::now();
+#endif
+}
+
+} // namespace
+
+class LogHistogramSample::Impl {
+ public:
+  virtual ~Impl() {}
+  virtual void Clear() = 0;
+  virtual std::uint64_t size() const = 0;
+  virtual std::uint64_t size(SystemClock::time_point timestamp) const = 0;
+  virtual void Update(std::int64_t value) = 0;
+  virtual void Update(std::int64_t value, SystemClock::time_point timestamp) = 0;
+  virtual void UpdateMany(const std::vector<std::int64_t>& values,
+                          SystemClock::time_point timestamp) = 0;
+  virtual Snapshot MakeSnapshot(uint64_t divisor = 1) const = 0;
+  virtual Snapshot MakeSnapshot(SystemClock::time_point timestamp,
+                                uint64_t divisor = 1) const = 0;
+};
+
+template <typename Counter>
+class LogHistogramSampleImpl : public LogHistogramSample::Impl {
+  static_assert(std::is_unsigned<Counter>::value, "Counter must be unsigned");
+
+ public:
+  explicit LogHistogramSampleImpl(const LogHistogramSample::Config& config);
+  ~LogHistogramSampleImpl() override;
+  void Clear() override;
+  std::uint64_t size() const override;
+  std::uint64_t size(SystemClock::time_point timestamp) const override;
+  void Update(std::int64_t value) override;
+  void Update(std::int64_t value, SystemClock::time_point timestamp) override;
+  void UpdateMany(const std::vector<std::int64_t>& values,
+                  SystemClock::time_point timestamp) override;
+  Snapshot MakeSnapshot(uint64_t divisor = 1) const override;
+  Snapshot MakeSnapshot(SystemClock::time_point timestamp,
+                        uint64_t divisor = 1) const override;
+
+ private:
+  class Window {
+   public:
+    Window();
+    void Init(std::size_t bucket_count);
+    void ClearTo(std::int64_t window_start);
+    void Record(std::size_t bucket, std::int64_t value);
+    std::uint64_t Size() const;
+    std::int64_t Max() const;
+    void CopyCounts(std::vector<std::uint64_t>& out) const;
+    std::atomic<std::int64_t> window_start_;
+
+   private:
+    std::vector<std::atomic<Counter>> buckets_;
+    std::atomic<std::uint64_t> size_;
+    std::atomic<std::int64_t> max_;
+  };
+
+  std::int64_t WindowStart(SystemClock::time_point timestamp) const;
+  std::size_t WindowIndex(std::int64_t window_start) const;
+  void PrepareWindow(Window& window, std::int64_t window_start) const;
+  std::size_t Bucket(std::int64_t value) const;
+  std::size_t MagnitudeBucket(std::uint64_t magnitude) const;
+
+  std::chrono::seconds const window_size_;
+  std::int64_t const window_size_seconds_;
+  std::size_t const buckets_per_level_;
+  std::size_t const sub_bucket_bits_;
+  std::uint64_t const max_absolute_value_;
+  std::size_t const magnitude_buckets_;
+  std::size_t const bucket_count_;
+  Window windows_[2];
+};
+
+LogHistogramSample::LogHistogramSample(std::chrono::seconds window_size,
+                                       std::size_t buckets_per_level)
+    : LogHistogramSample(Config{window_size, buckets_per_level}) {
+}
+
+LogHistogramSample::LogHistogramSample(const Config& config) {
+  if (config.max_events_per_window <= std::numeric_limits<std::uint16_t>::max()) {
+    impl_ = std::unique_ptr<Impl>(new LogHistogramSampleImpl<std::uint16_t>(config));
+  } else if (config.max_events_per_window <=
+             std::numeric_limits<std::uint32_t>::max()) {
+    impl_ = std::unique_ptr<Impl>(new LogHistogramSampleImpl<std::uint32_t>(config));
+  } else {
+    impl_ = std::unique_ptr<Impl>(new LogHistogramSampleImpl<std::uint64_t>(config));
+  }
+}
+
+LogHistogramSample::~LogHistogramSample() {
+}
+
+void LogHistogramSample::Clear() {
+  impl_->Clear();
+}
+
+std::uint64_t LogHistogramSample::size() const {
+  return impl_->size();
+}
+
+std::uint64_t LogHistogramSample::size(SystemClock::time_point timestamp) const {
+  return impl_->size(timestamp);
+}
+
+void LogHistogramSample::Update(std::int64_t value) {
+  impl_->Update(value);
+}
+
+void LogHistogramSample::Update(std::int64_t value,
+                                SystemClock::time_point timestamp) {
+  impl_->Update(value, timestamp);
+}
+
+void LogHistogramSample::UpdateMany(const std::vector<std::int64_t>& values) {
+  impl_->UpdateMany(values, CoarseNow());
+}
+
+void LogHistogramSample::UpdateMany(const std::vector<std::int64_t>& values,
+                                    SystemClock::time_point timestamp) {
+  impl_->UpdateMany(values, timestamp);
+}
+
+Snapshot LogHistogramSample::MakeSnapshot(uint64_t divisor) const {
+  return impl_->MakeSnapshot(divisor);
+}
+
+Snapshot LogHistogramSample::MakeSnapshot(SystemClock::time_point timestamp,
+                                          uint64_t divisor) const {
+  return impl_->MakeSnapshot(timestamp, divisor);
+}
+
+template <typename Counter>
+LogHistogramSampleImpl<Counter>::Window::Window()
+    : window_start_(kInvalidWindow), buckets_(), size_(0),
+      max_(std::numeric_limits<std::int64_t>::min()) {
+}
+
+template <typename Counter>
+void LogHistogramSampleImpl<Counter>::Window::Init(std::size_t bucket_count) {
+  std::vector<std::atomic<Counter>> buckets(bucket_count);
+  buckets_.swap(buckets);
+  ClearTo(kInvalidWindow);
+}
+
+template <typename Counter>
+void LogHistogramSampleImpl<Counter>::Window::ClearTo(std::int64_t window_start) {
+  window_start_.store(kPreparingWindow, std::memory_order_release);
+  for (auto& bucket : buckets_) {
+    bucket.store(0, std::memory_order_relaxed);
+  }
+  size_.store(0, std::memory_order_relaxed);
+  max_.store(std::numeric_limits<std::int64_t>::min(), std::memory_order_relaxed);
+  window_start_.store(window_start, std::memory_order_release);
+}
+
+template <typename Counter>
+void LogHistogramSampleImpl<Counter>::Window::Record(std::size_t bucket,
+                                                     std::int64_t value) {
+  buckets_[bucket].fetch_add(1, std::memory_order_relaxed);
+  size_.fetch_add(1, std::memory_order_relaxed);
+
+  auto current = max_.load(std::memory_order_relaxed);
+  while (value > current &&
+         !max_.compare_exchange_weak(current, value,
+                                     std::memory_order_relaxed,
+                                     std::memory_order_relaxed)) {
+  }
+}
+
+template <typename Counter>
+std::uint64_t LogHistogramSampleImpl<Counter>::Window::Size() const {
+  return size_.load(std::memory_order_relaxed);
+}
+
+template <typename Counter>
+std::int64_t LogHistogramSampleImpl<Counter>::Window::Max() const {
+  return max_.load(std::memory_order_relaxed);
+}
+
+template <typename Counter>
+void LogHistogramSampleImpl<Counter>::Window::CopyCounts(
+    std::vector<std::uint64_t>& out) const {
+  out.resize(buckets_.size());
+  for (std::size_t i = 0; i < buckets_.size(); ++i) {
+    out[i] = buckets_[i].load(std::memory_order_relaxed);
+  }
+}
+
+template <typename Counter>
+LogHistogramSampleImpl<Counter>::LogHistogramSampleImpl(
+    const LogHistogramSample::Config& config)
+    : window_size_(config.window_size),
+      window_size_seconds_(config.window_size.count()),
+      buckets_per_level_(config.buckets_per_level),
+      sub_bucket_bits_(SubBucketBits(config.buckets_per_level)),
+      max_absolute_value_(config.max_absolute_value),
+      magnitude_buckets_(LevelsForMaxAbsoluteValue(config.max_absolute_value) *
+                         config.buckets_per_level),
+      bucket_count_(2 * magnitude_buckets_ + 1),
+      windows_() {
+  if (window_size_seconds_ <= 0) {
+    throw std::invalid_argument("window_size must be positive");
+  }
+  windows_[0].Init(bucket_count_);
+  windows_[1].Init(bucket_count_);
+}
+
+template <typename Counter>
+LogHistogramSampleImpl<Counter>::~LogHistogramSampleImpl() {
+}
+
+template <typename Counter>
+void LogHistogramSampleImpl<Counter>::Clear() {
+  windows_[0].ClearTo(kInvalidWindow);
+  windows_[1].ClearTo(kInvalidWindow);
+}
+
+template <typename Counter>
+std::int64_t LogHistogramSampleImpl<Counter>::WindowStart(
+    SystemClock::time_point timestamp) const {
+  auto seconds = std::chrono::duration_cast<std::chrono::seconds>(
+      timestamp.time_since_epoch()).count();
+  auto offset = seconds % window_size_seconds_;
+  if (offset < 0) {
+    offset += window_size_seconds_;
+  }
+  return seconds - offset;
+}
+
+template <typename Counter>
+std::size_t LogHistogramSampleImpl<Counter>::WindowIndex(
+    std::int64_t window_start) const {
+  auto sequence = window_start / window_size_seconds_;
+  return static_cast<std::size_t>(sequence & 1);
+}
+
+template <typename Counter>
+void LogHistogramSampleImpl<Counter>::PrepareWindow(
+    Window& window, std::int64_t window_start) const {
+  for (;;) {
+    auto current = window.window_start_.load(std::memory_order_acquire);
+    if (current == window_start) {
+      return;
+    }
+    if (current == kPreparingWindow) {
+      std::this_thread::yield();
+      continue;
+    }
+    if (window.window_start_.compare_exchange_strong(
+            current, kPreparingWindow, std::memory_order_acq_rel,
+            std::memory_order_acquire)) {
+      window.ClearTo(window_start);
+      return;
+    }
+  }
+}
+
+template <typename Counter>
+std::size_t LogHistogramSampleImpl<Counter>::MagnitudeBucket(
+    std::uint64_t magnitude) const {
+  magnitude = std::min(magnitude, max_absolute_value_);
+  auto level = FloorLog2(magnitude);
+  auto base = std::uint64_t{1} << level;
+  auto remainder = magnitude - base;
+  std::uint64_t offset;
+  if (level >= sub_bucket_bits_) {
+    offset = remainder >> (level - sub_bucket_bits_);
+  } else {
+    offset = remainder << (sub_bucket_bits_ - level);
+  }
+  return level * buckets_per_level_ + offset;
+}
+
+template <typename Counter>
+std::size_t LogHistogramSampleImpl<Counter>::Bucket(std::int64_t value) const {
+  if (value == 0) {
+    return magnitude_buckets_;
+  }
+
+  auto magnitude_bucket = MagnitudeBucket(Magnitude(value));
+  if (value < 0) {
+    return magnitude_buckets_ - 1 - magnitude_bucket;
+  }
+  return magnitude_buckets_ + 1 + magnitude_bucket;
+}
+
+template <typename Counter>
+void LogHistogramSampleImpl<Counter>::Update(std::int64_t value) {
+  Update(value, CoarseNow());
+}
+
+template <typename Counter>
+void LogHistogramSampleImpl<Counter>::Update(std::int64_t value,
+                                             SystemClock::time_point timestamp) {
+  auto window_start = WindowStart(timestamp);
+  auto& window = windows_[WindowIndex(window_start)];
+  PrepareWindow(window, window_start);
+  window.Record(Bucket(value), value);
+}
+
+template <typename Counter>
+void LogHistogramSampleImpl<Counter>::UpdateMany(
+    const std::vector<std::int64_t>& values,
+    SystemClock::time_point timestamp) {
+  auto window_start = WindowStart(timestamp);
+  auto& window = windows_[WindowIndex(window_start)];
+  PrepareWindow(window, window_start);
+  for (auto value : values) {
+    window.Record(Bucket(value), value);
+  }
+}
+
+template <typename Counter>
+std::uint64_t LogHistogramSampleImpl<Counter>::size(
+    SystemClock::time_point timestamp) const {
+  auto previous_start = WindowStart(timestamp) - window_size_seconds_;
+  auto const& window = windows_[WindowIndex(previous_start)];
+  if (window.window_start_.load(std::memory_order_acquire) != previous_start) {
+    return 0;
+  }
+  return window.Size();
+}
+
+template <typename Counter>
+std::uint64_t LogHistogramSampleImpl<Counter>::size() const {
+  return size(CoarseNow());
+}
+
+template <typename Counter>
+Snapshot LogHistogramSampleImpl<Counter>::MakeSnapshot(
+    SystemClock::time_point timestamp, uint64_t divisor) const {
+  auto previous_start = WindowStart(timestamp) - window_size_seconds_;
+  auto const& window = windows_[WindowIndex(previous_start)];
+  if (window.window_start_.load(std::memory_order_acquire) != previous_start) {
+    return {std::vector<std::uint64_t>(bucket_count_), buckets_per_level_, 0, divisor};
+  }
+
+  std::vector<std::uint64_t> counts;
+  window.CopyCounts(counts);
+  auto max = window.Max();
+  if (window.window_start_.load(std::memory_order_acquire) != previous_start) {
+    return {std::vector<std::uint64_t>(bucket_count_), buckets_per_level_, 0, divisor};
+  }
+  return {counts, buckets_per_level_, max, divisor};
+}
+
+template <typename Counter>
+Snapshot LogHistogramSampleImpl<Counter>::MakeSnapshot(uint64_t divisor) const {
+  return MakeSnapshot(CoarseNow(), divisor);
+}
+
+} // namespace stats
+} // namespace medida

--- a/src/medida/stats/log_histogram_sample.h
+++ b/src/medida/stats/log_histogram_sample.h
@@ -1,0 +1,70 @@
+// Copyright 2026 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#ifndef MEDIDA_LOG_HISTOGRAM_SAMPLE_H_
+#define MEDIDA_LOG_HISTOGRAM_SAMPLE_H_
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <vector>
+
+#include "medida/types.h"
+#include "medida/stats/sample.h"
+#include "medida/stats/snapshot.h"
+
+namespace medida {
+namespace stats {
+
+// LogHistogramSample is a low-overhead alternative to CKMSSample. It keeps two
+// fixed time windows and records into logarithmic buckets with relaxed atomic
+// increments. Updates allocate no memory and take no locks.
+//
+// buckets_per_level must be a power of two. The default of 8 gives up to 12.5%
+// bucket-width granularity per power-of-two value range, and about half that
+// when reporting bucket midpoints.
+class LogHistogramSample : public Sample {
+ public:
+  static const std::size_t kDefaultBucketsPerLevel = 8;
+  static const std::uint64_t kDefaultMaxAbsoluteValue =
+      (std::uint64_t{1} << 48) - 1;
+  static const std::uint64_t kDefaultMaxEventsPerWindow =
+      std::numeric_limits<std::uint32_t>::max();
+
+  struct Config {
+    std::chrono::seconds window_size = std::chrono::seconds(30);
+    std::size_t buckets_per_level = kDefaultBucketsPerLevel;
+    std::uint64_t max_absolute_value = kDefaultMaxAbsoluteValue;
+    std::uint64_t max_events_per_window = kDefaultMaxEventsPerWindow;
+  };
+
+  LogHistogramSample(
+      std::chrono::seconds window_size = std::chrono::seconds(30),
+      std::size_t buckets_per_level = kDefaultBucketsPerLevel);
+  explicit LogHistogramSample(const Config& config);
+  ~LogHistogramSample();
+
+  virtual void Clear() override;
+  virtual std::uint64_t size() const override;
+  virtual std::uint64_t size(SystemClock::time_point timestamp) const;
+  virtual void Update(std::int64_t value) override;
+  virtual void Update(std::int64_t value, SystemClock::time_point timestamp);
+  virtual void UpdateMany(const std::vector<std::int64_t>& values) override;
+  virtual void UpdateMany(const std::vector<std::int64_t>& values,
+                          SystemClock::time_point timestamp);
+  virtual Snapshot MakeSnapshot(uint64_t divisor = 1) const override;
+  virtual Snapshot MakeSnapshot(SystemClock::time_point timestamp,
+                                uint64_t divisor = 1) const;
+  class Impl;
+
+ private:
+  std::unique_ptr<Impl> impl_;
+};
+
+} // namespace stats
+} // namespace medida
+
+#endif // MEDIDA_LOG_HISTOGRAM_SAMPLE_H_

--- a/src/medida/stats/snapshot.cc
+++ b/src/medida/stats/snapshot.cc
@@ -5,8 +5,10 @@
 #include "medida/stats/snapshot.h"
 
 #include <algorithm>
+#include <bit>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <stdexcept>
 #include <cassert>
 
@@ -64,12 +66,47 @@ class Snapshot::CKMSImpl : public Snapshot::Impl {
 };
 
 
+class Snapshot::LogHistogramImpl : public Snapshot::Impl {
+ public:
+  LogHistogramImpl(const std::vector<std::uint64_t>& counts,
+                   std::size_t buckets_per_level,
+                   std::int64_t max,
+                   uint64_t divisor = 1);
+  ~LogHistogramImpl();
+  std::size_t size() const override;
+  double getValue(double quantile) const override;
+  double max() const override;
+  std::vector<double> getValues() const override;
+ private:
+  double BucketValue(std::size_t bucket) const;
+  double MagnitudeBucketValue(std::size_t bucket) const;
+
+  std::vector<std::uint64_t> counts_;
+  std::size_t const buckets_per_level_;
+  std::size_t const sub_bucket_bits_;
+  std::size_t const magnitude_buckets_;
+  std::uint64_t size_;
+  std::int64_t const max_;
+  uint64_t const divisor_;
+};
+
+
 Snapshot::Snapshot(const std::vector<double>& values, uint64_t divisor)
   : impl_ {new Snapshot::VectorImpl {values, divisor}} {
 }
 
 Snapshot::Snapshot(const CKMS& ckms, uint64_t divisor)
   : impl_ {new Snapshot::CKMSImpl {ckms, divisor}} {
+}
+
+Snapshot::Snapshot(const std::vector<std::uint64_t>& log_histogram_counts,
+                   std::size_t buckets_per_level,
+                   std::int64_t max,
+                   uint64_t divisor)
+  : impl_ {new Snapshot::LogHistogramImpl {log_histogram_counts,
+                                           buckets_per_level,
+                                           max,
+                                           divisor}} {
 }
 
 Snapshot::Snapshot(Snapshot&& other)
@@ -266,6 +303,101 @@ double Snapshot::CKMSImpl::max() const {
 
 double Snapshot::CKMSImpl::getValue(double quantile) const {
     return ckms_->get(quantile) / (double) divisor_;
+}
+
+Snapshot::LogHistogramImpl::LogHistogramImpl(
+    const std::vector<std::uint64_t>& counts,
+    std::size_t buckets_per_level,
+    std::int64_t max,
+    uint64_t divisor)
+    : counts_(counts),
+      buckets_per_level_(buckets_per_level),
+      sub_bucket_bits_(buckets_per_level == 0 ? 0 :
+                       static_cast<std::size_t>(std::bit_width(buckets_per_level) - 1)),
+      magnitude_buckets_((counts.size() - 1) / 2),
+      size_(0),
+      max_(max),
+      divisor_(divisor) {
+  for (auto count : counts_) {
+    size_ += count;
+  }
+}
+
+Snapshot::LogHistogramImpl::~LogHistogramImpl() {
+}
+
+std::size_t Snapshot::LogHistogramImpl::size() const {
+  return size_;
+}
+
+double Snapshot::LogHistogramImpl::max() const {
+  if (size_ == 0) {
+    return 0.0;
+  }
+  return max_ / (double) divisor_;
+}
+
+std::vector<double> Snapshot::LogHistogramImpl::getValues() const {
+  throw std::runtime_error("Can't return the values since log histogram doesn't have them");
+}
+
+double Snapshot::LogHistogramImpl::MagnitudeBucketValue(std::size_t bucket) const {
+  std::size_t const level = bucket / buckets_per_level_;
+  std::size_t const offset = bucket % buckets_per_level_;
+
+  if (level >= 63) {
+    return std::ldexp(1.0, 63);
+  }
+
+  double const base = std::ldexp(1.0, static_cast<int>(level));
+  if (level >= sub_bucket_bits_) {
+    double const width = std::ldexp(1.0,
+                                   static_cast<int>(level - sub_bucket_bits_));
+    return base + (offset + 0.5) * width;
+  }
+
+  std::size_t const shift = sub_bucket_bits_ - level;
+  return base + static_cast<double>(offset >> shift);
+}
+
+double Snapshot::LogHistogramImpl::BucketValue(std::size_t bucket) const {
+  if (bucket < magnitude_buckets_) {
+    return -MagnitudeBucketValue(magnitude_buckets_ - 1 - bucket);
+  }
+  if (bucket == magnitude_buckets_) {
+    return 0.0;
+  }
+  return MagnitudeBucketValue(bucket - magnitude_buckets_ - 1);
+}
+
+double Snapshot::LogHistogramImpl::getValue(double quantile) const {
+  if (quantile < 0.0 || quantile > 1.0)
+  {
+      throw std::invalid_argument("quantile is not in [0..1]");
+  }
+
+  if (size_ == 0) {
+    return 0.0;
+  }
+
+  if (quantile == 1.0) {
+    return max();
+  }
+
+  std::uint64_t rank = static_cast<std::uint64_t>(std::ceil(quantile * size_));
+  if (rank == 0) {
+    rank = 1;
+  }
+
+  std::uint64_t cumulative = 0;
+  for (std::size_t i = 0; i < counts_.size(); ++i) {
+    cumulative += counts_[i];
+    if (cumulative >= rank) {
+      return BucketValue(i) / (double) divisor_;
+    }
+  }
+
+  return max();
 }
 
 double Snapshot::Impl::getMedian() const {

--- a/src/medida/stats/snapshot.h
+++ b/src/medida/stats/snapshot.h
@@ -7,6 +7,8 @@
 
 #include "medida/stats/ckms.h"
 
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <vector>
 
@@ -17,6 +19,10 @@ class Snapshot {
  public:
   Snapshot(const std::vector<double>& values, uint64_t divisor = 1);
   Snapshot(const CKMS& ckms, uint64_t divisor = 1);
+  Snapshot(const std::vector<std::uint64_t>& log_histogram_counts,
+           std::size_t buckets_per_level,
+           std::int64_t max,
+           uint64_t divisor = 1);
   ~Snapshot();
   Snapshot(Snapshot const&) = delete;
   Snapshot& operator=(Snapshot const&) = delete;
@@ -34,6 +40,7 @@ class Snapshot {
   class Impl;
   class VectorImpl;
   class CKMSImpl;
+  class LogHistogramImpl;
  private:
   void checkImpl() const;
   std::unique_ptr<Impl> impl_;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,8 @@ set(test_sources
   reporting/test_json_reporter.cc
   stats/test_ckms.cc
   stats/test_ckms_sample.cc
+  stats/test_log_histogram_sample.cc
+  stats/test_sample_benchmark.cc
   stats/test_ewma.cc
   stats/test_exp_decay_sample.cc
   stats/test_snapshot.cc

--- a/test/stats/test_log_histogram_sample.cc
+++ b/test/stats/test_log_histogram_sample.cc
@@ -1,0 +1,146 @@
+#include "medida/stats/log_histogram_sample.h"
+
+#include <gtest/gtest.h>
+#include <limits>
+
+using namespace medida::stats;
+
+TEST(LogHistogramSampleTest, aSameValueEverySecond) {
+  LogHistogramSample sample;
+
+  auto t = medida::SystemClock::time_point();
+  for (auto i = 0; i < 300; i++) {
+    t += std::chrono::seconds(1);
+    sample.Update(100, t);
+  }
+
+  EXPECT_EQ(30, sample.size(t));
+
+  auto snapshot = sample.MakeSnapshot(t);
+  EXPECT_EQ(30, snapshot.size());
+  EXPECT_NEAR(100, snapshot.getValue(0.5), 5);
+  EXPECT_NEAR(100, snapshot.getValue(0.99), 5);
+  EXPECT_EQ(100, snapshot.getValue(1));
+}
+
+TEST(LogHistogramSampleTest, aThreeDifferentValues) {
+  LogHistogramSample sample;
+
+  auto t = medida::SystemClock::time_point();
+  for (auto i = 0; i < 300; i++) {
+    t += std::chrono::seconds(1);
+    sample.Update(i % 3, t);
+  }
+
+  auto snapshot = sample.MakeSnapshot(t);
+
+  EXPECT_EQ(30, snapshot.size());
+  EXPECT_EQ(1, snapshot.getValue(0.5));
+  EXPECT_EQ(2, snapshot.getValue(0.99));
+  EXPECT_EQ(2, snapshot.getValue(1));
+}
+
+TEST(LogHistogramSampleTest, aSnapshotReturnsPreviousWindow) {
+  LogHistogramSample sample;
+
+  auto t = medida::SystemClock::time_point();
+  for (auto i = 0; i < 45; i++) {
+    sample.Update(i < 30 ? 1 : 2, t);
+    t += std::chrono::seconds(1);
+  }
+
+  auto snapshot = sample.MakeSnapshot(t);
+
+  EXPECT_EQ(30, snapshot.size());
+  EXPECT_EQ(1, snapshot.getValue(0.5));
+}
+
+TEST(LogHistogramSampleTest, aSnapshotDropsHugeGaps) {
+  LogHistogramSample sample;
+
+  auto t = medida::SystemClock::time_point();
+  for (auto i = 0; i < 10; i++) {
+    sample.Update(1, t);
+  }
+
+  t += std::chrono::seconds(100);
+  sample.Update(10, t);
+  sample.Update(10, t);
+
+  t += std::chrono::seconds(30);
+
+  auto snapshot = sample.MakeSnapshot(t);
+  EXPECT_EQ(2, snapshot.size());
+  EXPECT_EQ(10, snapshot.getValue(1));
+}
+
+TEST(LogHistogramSampleTest, aSpikyInputs) {
+  LogHistogramSample sample;
+
+  auto t = medida::SystemClock::time_point();
+
+  auto const size = 100000;
+  for (auto i = 0; i < 5; i++) {
+    t += std::chrono::seconds(30);
+    for (int j = 1; j <= size; j++) {
+      sample.Update(j, t);
+    }
+  }
+
+  auto snapshot = sample.MakeSnapshot(t);
+
+  EXPECT_EQ(size, snapshot.size());
+  EXPECT_NEAR(size * 0.5, snapshot.getValue(0.5), size * 0.05);
+  EXPECT_NEAR(size * 0.99, snapshot.getValue(0.99), size * 0.05);
+  EXPECT_EQ(size, snapshot.getValue(1));
+}
+
+TEST(LogHistogramSampleTest, supportsNegativeValues) {
+  LogHistogramSample sample;
+  auto t = medida::SystemClock::time_point();
+
+  sample.Update(-100, t);
+  sample.Update(-10, t);
+  sample.Update(0, t);
+  sample.Update(10, t);
+  sample.Update(100, t);
+
+  t += std::chrono::seconds(30);
+  auto snapshot = sample.MakeSnapshot(t);
+
+  EXPECT_EQ(5, snapshot.size());
+  EXPECT_LT(snapshot.getValue(0), -90);
+  EXPECT_EQ(0, snapshot.getValue(0.5));
+  EXPECT_EQ(100, snapshot.getValue(1));
+}
+
+TEST(LogHistogramSampleTest, requiresPowerOfTwoBucketsPerLevel) {
+  EXPECT_THROW(LogHistogramSample(std::chrono::seconds(30), 15),
+               std::invalid_argument);
+  EXPECT_NO_THROW(LogHistogramSample(std::chrono::seconds(30), 16));
+}
+
+TEST(LogHistogramSampleTest, supportsCompactConfig) {
+  LogHistogramSample::Config config;
+  config.buckets_per_level = 8;
+  config.max_absolute_value = 15;
+  config.max_events_per_window = std::numeric_limits<std::uint16_t>::max();
+  LogHistogramSample sample(config);
+
+  auto t = medida::SystemClock::time_point();
+  sample.Update(100, t);
+
+  t += std::chrono::seconds(30);
+  auto snapshot = sample.MakeSnapshot(t);
+
+  EXPECT_EQ(1, snapshot.size());
+  EXPECT_LE(snapshot.getValue(0.5), 16);
+  EXPECT_EQ(100, snapshot.max());
+}
+
+TEST(LogHistogramSampleTest, requiresPositiveMaxAbsoluteValue) {
+  LogHistogramSample::Config config;
+  config.max_absolute_value = 0;
+
+  EXPECT_THROW(LogHistogramSample sample(config), std::invalid_argument);
+}

--- a/test/stats/test_sample_benchmark.cc
+++ b/test/stats/test_sample_benchmark.cc
@@ -1,0 +1,272 @@
+#include "medida/stats/ckms_sample.h"
+#include "medida/stats/log_histogram_sample.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace medida::stats;
+
+namespace {
+
+struct Result {
+  std::string name;
+  std::size_t samples;
+  std::chrono::nanoseconds elapsed;
+};
+
+struct LatencyResult {
+  std::string name;
+  std::size_t samples;
+  std::chrono::nanoseconds min;
+  std::chrono::nanoseconds median;
+  std::chrono::nanoseconds p99;
+  std::chrono::nanoseconds max;
+  std::chrono::nanoseconds total;
+};
+
+std::vector<std::int64_t> MakeValues(std::size_t samples) {
+  std::vector<std::int64_t> values;
+  values.reserve(samples);
+
+  std::uint64_t x = 0x123456789abcdefULL;
+  for (std::size_t i = 0; i < samples; ++i) {
+    x = x * 2862933555777941757ULL + 3037000493ULL;
+    values.push_back(static_cast<std::int64_t>((x >> 16) % 1000000));
+  }
+  return values;
+}
+
+template <typename Fn>
+Result Measure(const std::string& name, std::size_t samples, Fn fn) {
+  auto start = std::chrono::steady_clock::now();
+  fn();
+  auto end = std::chrono::steady_clock::now();
+  return {name, samples, std::chrono::duration_cast<std::chrono::nanoseconds>(end - start)};
+}
+
+void PrintResult(const Result& result) {
+  auto ns_per_sample = static_cast<double>(result.elapsed.count()) /
+                       static_cast<double>(result.samples);
+  auto samples_per_second = 1e9 / ns_per_sample;
+
+  std::cerr << std::left << std::setw(36) << result.name << "  "
+            << std::right << std::setw(12) << result.elapsed.count() / 1000000.0
+            << " ms  " << std::setw(10) << ns_per_sample << " ns/update  "
+            << std::setw(12) << samples_per_second << " updates/s\n";
+}
+
+void PrintLatencyResult(const LatencyResult& result) {
+  auto mean = static_cast<double>(result.total.count()) /
+              static_cast<double>(result.samples);
+
+  std::cerr << std::left << std::setw(28) << result.name << "  "
+            << std::right << "min " << std::setw(8) << result.min.count()
+            << " ns  median " << std::setw(8) << result.median.count()
+            << " ns  p99 " << std::setw(8) << result.p99.count()
+            << " ns  max " << std::setw(10) << result.max.count()
+            << " ns  mean " << std::setw(10) << mean << " ns\n";
+}
+
+template <typename Sample>
+void UpdateWithTimestamp(Sample& sample, const std::vector<std::int64_t>& values,
+                         medida::SystemClock::time_point timestamp) {
+  for (auto value : values) {
+    sample.Update(value, timestamp);
+  }
+}
+
+template <typename Sample>
+void UpdateWithClock(Sample& sample, const std::vector<std::int64_t>& values) {
+  for (auto value : values) {
+    sample.Update(value);
+  }
+}
+
+template <typename Sample>
+LatencyResult MeasureUpdateLatencies(const std::string& name, Sample& sample,
+                                     const std::vector<std::int64_t>& values,
+                                     medida::SystemClock::time_point timestamp) {
+  std::vector<std::chrono::nanoseconds> timings;
+  timings.reserve(values.size());
+  auto total = std::chrono::nanoseconds{0};
+
+  for (auto value : values) {
+    auto start = std::chrono::steady_clock::now();
+    sample.Update(value, timestamp);
+    auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now() - start);
+    timings.push_back(elapsed);
+    total += elapsed;
+  }
+
+  std::sort(timings.begin(), timings.end());
+  auto p99_index = static_cast<std::size_t>(values.size() * 99 / 100);
+  if (p99_index >= timings.size()) {
+    p99_index = timings.size() - 1;
+  }
+
+  return {name,
+          values.size(),
+          timings.front(),
+          timings[timings.size() / 2],
+          timings[p99_index],
+          timings.back(),
+          total};
+}
+
+template <typename Sample>
+Result MeasureContendedUpdates(const std::string& name, Sample& sample,
+                               const std::vector<std::int64_t>& values,
+                               std::size_t thread_count,
+                               medida::SystemClock::time_point timestamp) {
+  std::vector<std::thread> threads;
+  threads.reserve(thread_count);
+
+  return Measure(name, values.size() * thread_count, [&] {
+    for (std::size_t i = 0; i < thread_count; ++i) {
+      threads.emplace_back([&] {
+        UpdateWithTimestamp(sample, values, timestamp);
+      });
+    }
+    for (auto& thread : threads) {
+      thread.join();
+    }
+  });
+}
+
+} // namespace
+
+TEST(SampleBenchmarkTest, DISABLED_updateThroughput) {
+  auto const samples = std::size_t{1000000};
+  auto values = MakeValues(samples);
+  auto timestamp = medida::SystemClock::time_point{};
+
+  std::cerr << "\nSample update benchmark (" << samples << " values)\n";
+  std::cerr << "Run manually with:\n"
+            << "  ./build/test/test-medida --gtest_also_run_disabled_tests "
+            << "--gtest_filter=SampleBenchmarkTest.DISABLED_updateThroughput\n\n";
+
+  {
+    CKMSSample sample;
+    auto result = Measure("CKMS Update(value, timestamp)", samples, [&] {
+      UpdateWithTimestamp(sample, values, timestamp);
+    });
+    EXPECT_EQ(samples, sample.MakeSnapshot(timestamp + std::chrono::seconds(30)).size());
+    PrintResult(result);
+  }
+
+  {
+    LogHistogramSample sample;
+    auto result = Measure("LogHistogram Update(value, timestamp)", samples, [&] {
+      UpdateWithTimestamp(sample, values, timestamp);
+    });
+    EXPECT_EQ(samples, sample.MakeSnapshot(timestamp + std::chrono::seconds(30)).size());
+    PrintResult(result);
+  }
+
+  {
+    CKMSSample sample;
+    auto result = Measure("CKMS Update(value)", samples, [&] {
+      UpdateWithClock(sample, values);
+    });
+    EXPECT_EQ(samples, sample.MakeSnapshot(medida::SystemClock::now() + std::chrono::seconds(30)).size());
+    PrintResult(result);
+  }
+
+  {
+    LogHistogramSample sample;
+    auto result = Measure("LogHistogram Update(value)", samples, [&] {
+      UpdateWithClock(sample, values);
+    });
+    EXPECT_EQ(samples, sample.MakeSnapshot(medida::SystemClock::now() + std::chrono::seconds(30)).size());
+    PrintResult(result);
+  }
+
+  {
+    CKMSSample sample;
+    auto result = Measure("CKMS UpdateMany(values, timestamp)", samples, [&] {
+      sample.UpdateMany(values, timestamp);
+    });
+    EXPECT_EQ(samples, sample.MakeSnapshot(timestamp + std::chrono::seconds(30)).size());
+    PrintResult(result);
+  }
+
+  {
+    LogHistogramSample sample;
+    auto result = Measure("LogHistogram UpdateMany(values, timestamp)", samples, [&] {
+      sample.UpdateMany(values, timestamp);
+    });
+    EXPECT_EQ(samples, sample.MakeSnapshot(timestamp + std::chrono::seconds(30)).size());
+    PrintResult(result);
+  }
+}
+
+TEST(SampleBenchmarkTest, DISABLED_contendedUpdateThroughput) {
+  auto const thread_count = std::size_t{8};
+  auto const samples_per_thread = std::size_t{250000};
+  auto const total_samples = thread_count * samples_per_thread;
+  auto values = MakeValues(samples_per_thread);
+  auto timestamp = medida::SystemClock::time_point{};
+
+  std::cerr << "\nContended sample update benchmark (" << thread_count
+            << " threads, " << samples_per_thread << " values/thread)\n";
+  std::cerr << "Run manually with:\n"
+            << "  ./build/test/test-medida --gtest_also_run_disabled_tests "
+            << "--gtest_filter=SampleBenchmarkTest.DISABLED_contendedUpdateThroughput\n\n";
+
+  {
+    CKMSSample sample;
+    auto result = MeasureContendedUpdates("CKMS contended Update(timestamp)",
+                                          sample, values, thread_count,
+                                          timestamp);
+    EXPECT_EQ(total_samples,
+              sample.MakeSnapshot(timestamp + std::chrono::seconds(30)).size());
+    PrintResult(result);
+  }
+
+  {
+    LogHistogramSample sample;
+    auto result = MeasureContendedUpdates("LogHistogram contended Update(timestamp)",
+                                          sample, values, thread_count,
+                                          timestamp);
+    EXPECT_EQ(total_samples,
+              sample.MakeSnapshot(timestamp + std::chrono::seconds(30)).size());
+    PrintResult(result);
+  }
+}
+
+TEST(SampleBenchmarkTest, DISABLED_updateLatencySpikes) {
+  auto const samples = std::size_t{200000};
+  auto values = MakeValues(samples);
+  auto timestamp = medida::SystemClock::time_point{};
+
+  std::cerr << "\nPer-update latency benchmark (" << samples << " values)\n";
+  std::cerr << "Run manually with:\n"
+            << "  ./build/test/test-medida --gtest_also_run_disabled_tests "
+            << "--gtest_filter=SampleBenchmarkTest.DISABLED_updateLatencySpikes\n\n";
+
+  {
+    CKMSSample sample;
+    auto result = MeasureUpdateLatencies("CKMS Update(timestamp)", sample,
+                                         values, timestamp);
+    EXPECT_EQ(samples, sample.MakeSnapshot(timestamp + std::chrono::seconds(30)).size());
+    PrintLatencyResult(result);
+  }
+
+  {
+    LogHistogramSample sample;
+    auto result = MeasureUpdateLatencies("LogHistogram Update(timestamp)", sample,
+                                         values, timestamp);
+    EXPECT_EQ(samples, sample.MakeSnapshot(timestamp + std::chrono::seconds(30)).size());
+    PrintLatencyResult(result);
+  }
+}

--- a/test/test_histogram.cc
+++ b/test/test_histogram.cc
@@ -120,6 +120,21 @@ TEST(HistogramTest, ckmsMetrics) {
   EXPECT_EQ(7, h.count());
 }
 
+TEST(HistogramTest, logHistogramMetrics) {
+  MetricsRegistry r {std::chrono::seconds(1)};
+  auto& h = r.NewHistogram({"a", "b", "c"}, SamplingInterface::kLogHistogram);
+
+  for (int i = 1; i <= 7; i++) {
+      h.Update(i);
+  }
+
+  EXPECT_EQ(1, h.min());
+  EXPECT_EQ(7, h.max());
+  EXPECT_NEAR(2.1602468994693, h.std_dev(), 1e-6);
+  EXPECT_EQ(28, h.sum());
+  EXPECT_EQ(7, h.count());
+}
+
 TEST(HistogramTest, updateManyIsSafeWithConcurrentReaders) {
   MetricsRegistry registry {};
   auto& histogram = registry.NewHistogram({"a", "b", "c"}, SamplingInterface::kUniform);


### PR DESCRIPTION
Given that we're interested in _fast_ metrics too -- not just accurate -- I decided to have GPT 5.5 code up a fast atomics-only non-allocating bunched-log-histogram / HDRhistogram-esque variant of its Sample class. It's a lot faster than CKMS.

Uncontended:

```
CKMS Update(value, timestamp)              209.378 ns/update
LogHistogram Update(value, timestamp)        3.825 ns/update
CKMS Update(value)                         191.451 ns/update
LogHistogram Update(value)                   7.099 ns/update
CKMS UpdateMany(values, timestamp)         173.250 ns/update
LogHistogram UpdateMany(values, timestamp)   2.049 ns/update
```

Contended:
```
CKMS contended Update(timestamp)              249.629 ns/update
LogHistogram contended Update(timestamp)       73.061 ns/update
```

Of course the resolution question. They are not entirely comparable: CKMS offers a fairly tight notion of accuracy, but it's in _rank space_ rather than in _value space_. The histogram's accuracy is dynamically controllable by the "buckets per level" parameter; it defaults to around 5%-error in order to save space, and you can spend more memory to tighten it as much as you like. The default size is around 3KiB per metric, smaller than CKMS is likely to be in its steady state (though notably both are used in a very weird swapping-windows mode where each instance only lives for 30 seconds anyways!)

The advantage of course is that the histogram is much faster and simpler and also you can query any percentile, not just the ones it's being tasked with maintaining (CKMS takes a fixed set of target percentiles to track).