### PR TITLE
added cstdint header

### DIFF
--- a/src/medida/stats/snapshot.h
+++ b/src/medida/stats/snapshot.h
@@ -9,6 +9,7 @@
 
 #include <memory>
 #include <vector>
+#include <cstdint>
 
 namespace medida {
 namespace stats {


### PR DESCRIPTION
The build with modern compilers like clang21 can't be done without explicit declaration of `cstdint` header on using standard integers such as `uint64_t`.